### PR TITLE
Accept empty `build-target`s and add Carbon Chain

### DIFF
--- a/chains.yaml
+++ b/chains.yaml
@@ -64,6 +64,56 @@
   build-env:
     - BUILD_TAGS=muslc
 
+# Carbon
+- name: carbon
+  github-organization: Switcheo
+  github-repo: carbon-bootstrap
+  language: rust
+  build-target:
+  pre-build: |
+    apt update && apt install wget build-essential jq cmake -y
+
+    wget https://github.com/google/leveldb/archive/1.23.tar.gz && \
+      tar -zxvf 1.23.tar.gz && \
+      wget https://github.com/google/googletest/archive/release-1.11.0.tar.gz && \
+      tar -zxvf release-1.11.0.tar.gz && \
+      mv googletest-release-1.11.0/* leveldb-1.23/third_party/googletest && \
+
+      wget https://github.com/google/benchmark/archive/v1.5.5.tar.gz && \
+      tar -zxvf v1.5.5.tar.gz && \
+      mv benchmark-1.5.5/* leveldb-1.23/third_party/benchmark && \
+
+      cd leveldb-1.23 && \
+      mkdir -p build && \
+
+      cd build && \
+      cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON .. && \
+      cmake --build . && \
+      cp -P libleveldb.so* /usr/local/lib/ && \
+      ldconfig && \
+      cd .. && \
+
+      cp -r include/leveldb /usr/local/include/ && \
+      cd .. && \
+
+      rm -rf benchmark-1.5.5/ && \
+      rm -f v1.5.5.tar.gz && \
+
+      rm -rf googletest-release-1.11.0/ && \
+      rm -f release-1.11.0.tar.gz && \
+
+      rm -rf leveldb-1.23/ && \
+      rm -f 1.23.tar.gz
+
+    VERSION=2.0.0
+    NETWORK=mainnet
+    wget https://github.com/Switcheo/carbon-bootstrap/releases/download/v${VERSION}/carbond${VERSION}-${NETWORK}.linux-$(dpkg --print-architecture).tar.gz
+    tar -xvf carbond${VERSION}-${NETWORK}.linux-$(dpkg --print-architecture).tar.gz
+    mv carbond /usr/local/bin
+    rm carbond${VERSION}-${NETWORK}.linux-amd64.tar.gz 
+  binaries:
+    - /usr/local/bin/carbond
+
 # Cosmos Hub
 - name: gaia
   github-organization: cosmos

--- a/dockerfile/rust/Dockerfile
+++ b/dockerfile/rust/Dockerfile
@@ -18,7 +18,9 @@ ARG VERSION
 
 RUN git checkout ${VERSION}
 
-RUN cargo fetch
+ARG BUILD_TARGET
+
+RUN [ ! -z "$BUILD_TARGET" ] && cargo fetch || true
 
 ARG TARGETARCH
 ARG TARGETOS
@@ -38,16 +40,16 @@ RUN [ ! -z "$PRE_BUILD" ] && sh -c "${PRE_BUILD}"; \
       apt install -y gcc-aarch64-linux-gnu; \
       dpkg --add-architecture arm64; \
       apt update && apt install -y libssl-dev:arm64; \
-      cargo ${BUILD_TARGET} --target $TARGET; \
+      [ ! -z "$BUILD_TARGET" ] && cargo ${BUILD_TARGET} --target $TARGET; \
     elif [ "$TARGETARCH" == "amd64" ] && [ "$BUILDARCH" != "amd64" ]; then \
       TARGET=x86_64-unknown-linux-gnu; \
       rustup target add $TARGET; \
       apt install -y gcc-x86_64-linux-gnu; \
       dpkg --add-architecture amd64; \
       apt update && apt install -y libssl-dev:amd64; \
-      cargo ${BUILD_TARGET} --target $TARGET; \
+      [ ! -z "$BUILD_TARGET" ] && cargo ${BUILD_TARGET} --target $TARGET; \
     else \
-      cargo ${BUILD_TARGET}; \
+      [ ! -z "$BUILD_TARGET" ] && cargo ${BUILD_TARGET}; \
     fi;
 
 RUN mkdir /root/bin
@@ -64,6 +66,10 @@ WORKDIR /root
 
 # Install chain binaries
 COPY --from=build-env /root/bin /usr/local/bin
+
+# Install libraries
+COPY --from=build-env /usr/local/lib /usr/local/lib
+RUN cp -r /usr/local/lib/* /lib/
 
 RUN groupadd -g 1025 -r heighliner && useradd -u 1025 --no-log-init -r -g heighliner heighliner
 WORKDIR /home/heighliner

--- a/dockerfile/sdk-rocksdb/Dockerfile
+++ b/dockerfile/sdk-rocksdb/Dockerfile
@@ -60,7 +60,7 @@ ARG PRE_BUILD
 RUN [ ! -z "$PRE_BUILD" ] && sh -c "${PRE_BUILD}"; \
     [ ! -z "$BUILD_ENV" ] && export ${BUILD_ENV}; \
     [ ! -z "$BUILD_TAGS" ] && export "${BUILD_TAGS}"; \
-    make ${BUILD_TARGET}
+    [ ! -z "$BUILD_TARGET" ] && make ${BUILD_TARGET} || true
 
 RUN mkdir /root/bin
 

--- a/dockerfile/sdk/Dockerfile
+++ b/dockerfile/sdk/Dockerfile
@@ -60,7 +60,7 @@ RUN if [ "${TARGETARCH}" = "arm64" ] && [ "${BUILDARCH}" != "arm64" ]; then \
     [ ! -z "$BUILD_ENV" ] && export ${BUILD_ENV}; \
     [ ! -z "$BUILD_TAGS" ] && export "${BUILD_TAGS}"; \
     [ ! -z "$BUILD_DIR" ] && cd "${BUILD_DIR}"; \
-    make ${BUILD_TARGET}
+    [ ! -z "$BUILD_TARGET" ] && make ${BUILD_TARGET} || true
 
 RUN [ -d "/go/bin/linux_${TARGETARCH}" ] && mv /go/bin/linux_${TARGETARCH}/* /go/bin/ || true
 
@@ -84,6 +84,7 @@ COPY --from=build-env /root/bin /usr/local/bin
 
 # Install libraries
 COPY --from=build-env /usr/local/lib /usr/local/lib
+RUN cp -r /usr/local/lib/* /lib/
 
 RUN addgroup --gid 1025 -S heighliner && adduser --uid 1025 -S heighliner -G heighliner
 WORKDIR /home/heighliner

--- a/dockerfile/sdk/native.Dockerfile
+++ b/dockerfile/sdk/native.Dockerfile
@@ -32,7 +32,7 @@ RUN [ ! -z "$PRE_BUILD" ] && sh -c "${PRE_BUILD}"; \
     [ ! -z "$BUILD_ENV" ] && export ${BUILD_ENV}; \
     [ ! -z "$BUILD_TAGS" ] && export "${BUILD_TAGS}"; \
     [ ! -z "$BUILD_DIR" ] && cd "${BUILD_DIR}"; \
-    make ${BUILD_TARGET}
+    [ ! -z "$BUILD_TARGET" ] && make ${BUILD_TARGET} || true
 
 RUN mkdir /root/bin
 ARG BINARIES
@@ -53,6 +53,7 @@ COPY --from=build-env /root/bin /usr/local/bin
 
 # Install libraries
 COPY --from=build-env /usr/local/lib /usr/local/lib
+RUN cp -r /usr/local/lib/* /lib/
 
 RUN addgroup --gid 1025 -S heighliner && adduser --uid 1025 -S heighliner -G heighliner
 WORKDIR /home/heighliner


### PR DESCRIPTION
Heighliner accepts empty build-targets. Necessary for running prebuilt binaries.

Also addresses copying installed libraries into a folder where the "heighliner" user doesn't need `sudo`.

@agouin I tried to replicate what we did in rust/native.Dockerfile across the other docker files. I'm sure I missed something. Give it a good look over. 