### PR TITLE
feat: Add du to images

### DIFF
--- a/busybox.min.config
+++ b/busybox.min.config
@@ -232,7 +232,7 @@ CONFIG_CAT=y
 # CONFIG_DIRNAME is not set
 # CONFIG_DOS2UNIX is not set
 # CONFIG_UNIX2DOS is not set
-# CONFIG_DU is not set
+CONFIG_DU=y
 # CONFIG_FEATURE_DU_DEFAULT_BLOCKSIZE_1K is not set
 # CONFIG_ECHO is not set
 # CONFIG_FEATURE_FANCY_ECHO is not set

--- a/dockerfile/sdk/Dockerfile
+++ b/dockerfile/sdk/Dockerfile
@@ -107,6 +107,7 @@ RUN ln sh pwd && \
     ln sh less && \
     ln sh grep && \
     ln sh sleep && \
+    ln sh du && \
     rm ln rm
 
 # Install chain binaries

--- a/dockerfile/sdk/native.Dockerfile
+++ b/dockerfile/sdk/native.Dockerfile
@@ -79,6 +79,7 @@ RUN ln sh pwd && \
     ln sh less && \
     ln sh grep && \
     ln sh sleep && \
+    ln sh du && \
     rm ln rm
 
 # Install chain binaries


### PR DESCRIPTION
I missed this today. Unfortunately, k8s doesn't easily let you see Volume used disk space, only the capacity.

I don't *think* `du` is a security risk. If so, please close this PR with a reason (so I'm educated!). 