### PR TITLE
Accept Empty Build Targets for Rust images and Add Carbon Chain

### DIFF
--- a/chains.yaml
+++ b/chains.yaml
@@ -116,10 +116,10 @@
       cd .. && \
       sudo cp -r include/leveldb /usr/local/include/ && \
       cd .. && \
-    VERSION=2.0.0
     NETWORK=mainnet
-    wget https://github.com/Switcheo/carbon-bootstrap/releases/download/v${VERSION}/carbond${VERSION}-${NETWORK}.linux-$(dpkg --print-architecture).tar.gz
-    tar -xvf carbond${VERSION}-${NETWORK}.linux-$(dpkg --print-architecture).tar.gz
+    VERSION_NUM=$(echo ${VERSION} | cut -c 2-)
+    wget https://github.com/Switcheo/carbon-bootstrap/releases/download/"${VERSION}"/carbond"${VERSION_NUM}"-${NETWORK}.linux-$(dpkg --print-architecture).tar.gz
+    tar -xvf carbond${VERSION_NUM}-${NETWORK}.linux-$(dpkg --print-architecture).tar.gz
     sudo mv carbond /usr/local/bin
   libraries:
     - /usr/local/lib/libleveldb.so.*

--- a/chains.yaml
+++ b/chains.yaml
@@ -90,6 +90,42 @@
   build-env:
     - BUILD_TAGS=muslc
 
+# Carbon
+- name: carbon
+  github-organization: Switcheo
+  github-repo: carbon-bootstrap
+  language: rust
+  build-target:
+  pre-build: |
+    apt update && apt install wget build-essential jq cmake sudo -y
+    wget https://github.com/google/leveldb/archive/1.23.tar.gz && \
+      tar -zxvf 1.23.tar.gz && \
+      wget https://github.com/google/googletest/archive/release-1.11.0.tar.gz && \
+      tar -zxvf release-1.11.0.tar.gz && \
+      mv googletest-release-1.11.0/* leveldb-1.23/third_party/googletest && \
+      wget https://github.com/google/benchmark/archive/v1.5.5.tar.gz && \
+      tar -zxvf v1.5.5.tar.gz && \
+      mv benchmark-1.5.5/* leveldb-1.23/third_party/benchmark && \
+      cd leveldb-1.23 && \
+      mkdir -p build && \
+      cd build && \
+      cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON .. && \
+      cmake --build . && \
+      sudo cp -P libleveldb.so* /usr/local/lib/ && \
+      sudo ldconfig && \
+      cd .. && \
+      sudo cp -r include/leveldb /usr/local/include/ && \
+      cd .. && \
+    VERSION=2.0.0
+    NETWORK=mainnet
+    wget https://github.com/Switcheo/carbon-bootstrap/releases/download/v${VERSION}/carbond${VERSION}-${NETWORK}.linux-$(dpkg --print-architecture).tar.gz
+    tar -xvf carbond${VERSION}-${NETWORK}.linux-$(dpkg --print-architecture).tar.gz
+    sudo mv carbond /usr/local/bin
+  libraries:
+    - /usr/local/lib/libleveldb.so.*
+  binaries:
+    - /usr/local/bin/carbond
+
 # Cerberus
 - name: cerberus
   github-organization: cerberus-zone

--- a/dockerfile/rust/Dockerfile
+++ b/dockerfile/rust/Dockerfile
@@ -18,8 +18,6 @@ WORKDIR /build/${GITHUB_REPO}
 
 RUN git checkout ${VERSION}
 
-# RUN cargo fetch
-
 ARG BUILD_TARGET
 ARG BUILD_ENV
 ARG BUILD_TAGS

--- a/dockerfile/rust/Dockerfile
+++ b/dockerfile/rust/Dockerfile
@@ -20,8 +20,7 @@ RUN git checkout ${VERSION}
 
 ARG BUILD_TARGET
 
-RUN if [ ! -z "$BUILD_TARGET" ]; then \
-      cargo fetch;
+RUN if [ ! -z "$BUILD_TARGET" ]; then cargo fetch; fi
 
 ARG BUILD_ENV
 ARG BUILD_TAGS

--- a/dockerfile/rust/Dockerfile
+++ b/dockerfile/rust/Dockerfile
@@ -26,6 +26,7 @@ ARG PRE_BUILD
 
 RUN if [ ! -z "$PRE_BUILD" ]; then sh -c "${PRE_BUILD}"; fi; \
     if [ ! -z "$BUILD_TARGET" ]; then \
+      cargo fetch; \
       if [ ! -z "$BUILD_ENV" ]; then export ${BUILD_ENV}; fi; \
       if [ ! -z "$BUILD_TAGS" ]; then export "${BUILD_TAGS}"; fi; \
       if [ ! -z "$BUILD_DIR" ]; then cd "${BUILD_DIR}"; fi; \

--- a/dockerfile/rust/Dockerfile
+++ b/dockerfile/rust/Dockerfile
@@ -18,22 +18,31 @@ WORKDIR /build/${GITHUB_REPO}
 
 RUN git checkout ${VERSION}
 
-RUN cargo fetch
+# RUN cargo fetch
 
 ARG BUILD_TARGET
 ARG BUILD_ENV
 ARG BUILD_TAGS
 ARG PRE_BUILD
 
-RUN [ ! -z "$PRE_BUILD" ] && sh -c "${PRE_BUILD}"; \
-    [ ! -z "$BUILD_ENV" ] && export ${BUILD_ENV}; \
-    [ ! -z "$BUILD_TAGS" ] && export "${BUILD_TAGS}"; \
-    cargo ${BUILD_TARGET}
+
+RUN if [ ! -z "$PRE_BUILD" ]; then sh -c "${PRE_BUILD}"; fi; \
+    if [ ! -z "$BUILD_TARGET" ]; then \
+      if [ ! -z "$BUILD_ENV" ]; then export ${BUILD_ENV}; fi; \
+      if [ ! -z "$BUILD_TAGS" ]; then export "${BUILD_TAGS}"; fi; \
+      if [ ! -z "$BUILD_DIR" ]; then cd "${BUILD_DIR}"; fi; \
+      cargo ${BUILD_TARGET}; \
+    fi
 
 RUN mkdir /root/bin
 ARG BINARIES
 ENV BINARIES_ENV ${BINARIES}
 RUN bash -c 'BINARIES_ARR=($BINARIES_ENV); for BINARY in "${BINARIES_ARR[@]}"; do cp $BINARY /root/bin/ ; done'
+
+RUN mkdir /root/lib
+ARG LIBRARIES
+ENV LIBRARIES_ENV ${LIBRARIES}
+RUN bash -c 'LIBRARIES_ARR=($LIBRARIES_ENV); for LIBRARY in "${LIBRARIES_ARR[@]}"; do cp $LIBRARY /root/lib/; done'
 
 FROM debian:bullseye
 
@@ -44,6 +53,9 @@ WORKDIR /root
 
 # Install chain binaries
 COPY --from=build-env /root/bin /usr/local/bin
+
+# Install libraries
+COPY --from=build-env /root/lib /lib
 
 RUN groupadd -g 1025 -r heighliner && useradd -u 1025 --no-log-init -r -g heighliner heighliner
 WORKDIR /home/heighliner

--- a/dockerfile/rust/Dockerfile
+++ b/dockerfile/rust/Dockerfile
@@ -19,14 +19,16 @@ WORKDIR /build/${GITHUB_REPO}
 RUN git checkout ${VERSION}
 
 ARG BUILD_TARGET
+
+RUN if [ ! -z "$BUILD_TARGET" ]; then \
+      cargo fetch;
+
 ARG BUILD_ENV
 ARG BUILD_TAGS
 ARG PRE_BUILD
 
-
 RUN if [ ! -z "$PRE_BUILD" ]; then sh -c "${PRE_BUILD}"; fi; \
     if [ ! -z "$BUILD_TARGET" ]; then \
-      cargo fetch; \
       if [ ! -z "$BUILD_ENV" ]; then export ${BUILD_ENV}; fi; \
       if [ ! -z "$BUILD_TAGS" ]; then export "${BUILD_TAGS}"; fi; \
       if [ ! -z "$BUILD_DIR" ]; then cd "${BUILD_DIR}"; fi; \


### PR DESCRIPTION
This PR:

- adds the ability for `language: rust` chains to accept empty build targets
- copies "lib" folder into Debian image 
- Adds Carbon Chain


Seems like `crossarch.Dockerfile` is un-used at the moment. Did not touch that file. Plus we are planning to start building docker images "from scratch"

Closes: https://github.com/strangelove-ventures/heighliner/issues/17
