### PR TITLE
Include trusted CA certs

### DIFF
--- a/dockerfile/sdk/Dockerfile
+++ b/dockerfile/sdk/Dockerfile
@@ -116,6 +116,9 @@ COPY --from=build-env /root/bin /bin
 # Install libraries
 COPY --from=build-env /root/lib /lib
 
+# Install trusted CA certificates
+COPY --from=build-env /etc/ssl/cert.pem /etc/ssl/cert.pem
+
 # Install heighliner user
 COPY --from=build-env /etc/passwd /etc/passwd
 COPY --from=build-env --chown=1025:1025 /home/heighliner /home/heighliner

--- a/dockerfile/sdk/native.Dockerfile
+++ b/dockerfile/sdk/native.Dockerfile
@@ -88,6 +88,9 @@ COPY --from=build-env /root/bin /bin
 # Install libraries
 COPY --from=build-env /root/lib /lib
 
+# Install trusted CA certificates
+COPY --from=build-env /etc/ssl/cert.pem /etc/ssl/cert.pem
+
 # Install heighliner user
 COPY --from=build-env /etc/passwd /etc/passwd
 COPY --from=build-env --chown=1025:1025 /home/heighliner /home/heighliner


### PR DESCRIPTION
No trusted CA root certs are present in the images now, so commands against TLS-secured remote nodes were not working:

```bash
$ docker run -it --rm --entrypoint osmosisd ghcr.io/strangelove-ventures/heighliner/osmosis:v11.0.1 q gov proposals --node https://rpc.osmosis.strange.love:443
Error: post failed: Post "https://rpc.osmosis.strange.love:443": x509: certificate signed by unknown authority
```

This brings over the alpine linux trusted CA list into the final images