### PR TITLE
Update chain names to match chain-registry

### DIFF
--- a/chains.yaml
+++ b/chains.yaml
@@ -435,8 +435,8 @@
   binaries:
     - /go/bin/liked
 
-# Lum 
-- name: lum
+# Lumnetwork 
+- name: lumnetwork
   github-organization: lum-network
   github-repo: chain
   language: go
@@ -453,8 +453,8 @@
   binaries:
     - /build/nomic/target/release/nomic
 
-#Omniflix
-- name: omniflix
+#Omniflixhub
+- name: omniflixhub
   github-organization: OmniFlix
   github-repo: omniflixhub
   language: go


### PR DESCRIPTION
For consistency, these names should be updated to match the `chain_name` on the chain registry.