### PR TITLE
Fix relative path binary copy

### DIFF
--- a/dockerfile/nix/Dockerfile
+++ b/dockerfile/nix/Dockerfile
@@ -74,15 +74,18 @@ ARG BINARIES
 ENV BINARIES_ENV ${BINARIES}
 RUN bash -c \
   'BINARIES_ARR=($BINARIES_ENV); \
-  cd /root/bin ; \
   for BINARY in "${BINARIES_ARR[@]}"; do \
     BINSPLIT=(${BINARY//:/ }) ; \
     BINPATH=${BINSPLIT[1]} ; \
     if [ ! -z "$BINPATH" ]; then \
-      mkdir -p "$(dirname "${BINPATH}")" ; \
-      cp ${BINSPLIT[0]} "${BINPATH}"; \
+      if [[ $BINPATH == *"/"* ]]; then \
+        mkdir -p "$(dirname "${BINPATH}")" ; \
+        cp ${BINSPLIT[0]} "${BINPATH}"; \
+      else \
+        cp ${BINSPLIT[0]} "/root/bin/${BINPATH}"; \
+      fi ;\
     else \
-      cp ${BINSPLIT[0]} . ; \
+      cp ${BINSPLIT[0]} /root/bin/ ; \
     fi; \
   done'
 

--- a/dockerfile/nix/native.Dockerfile
+++ b/dockerfile/nix/native.Dockerfile
@@ -49,15 +49,18 @@ ARG BINARIES
 ENV BINARIES_ENV ${BINARIES}
 RUN bash -c \
   'BINARIES_ARR=($BINARIES_ENV); \
-  cd /root/bin ; \
   for BINARY in "${BINARIES_ARR[@]}"; do \
     BINSPLIT=(${BINARY//:/ }) ; \
     BINPATH=${BINSPLIT[1]} ; \
     if [ ! -z "$BINPATH" ]; then \
-      mkdir -p "$(dirname "${BINPATH}")" ; \
-      cp ${BINSPLIT[0]} "${BINPATH}"; \
+      if [[ $BINPATH == *"/"* ]]; then \
+        mkdir -p "$(dirname "${BINPATH}")" ; \
+        cp ${BINSPLIT[0]} "${BINPATH}"; \
+      else \
+        cp ${BINSPLIT[0]} "/root/bin/${BINPATH}"; \
+      fi ;\
     else \
-      cp ${BINSPLIT[0]} . ; \
+      cp ${BINSPLIT[0]} /root/bin/ ; \
     fi; \
   done'
 

--- a/dockerfile/rust/Dockerfile
+++ b/dockerfile/rust/Dockerfile
@@ -41,15 +41,18 @@ ARG BINARIES
 ENV BINARIES_ENV ${BINARIES}
 RUN bash -c \
   'BINARIES_ARR=($BINARIES_ENV); \
-  cd /root/bin ; \
   for BINARY in "${BINARIES_ARR[@]}"; do \
     BINSPLIT=(${BINARY//:/ }) ; \
     BINPATH=${BINSPLIT[1]} ; \
     if [ ! -z "$BINPATH" ]; then \
-      mkdir -p "$(dirname "${BINPATH}")" ; \
-      cp ${BINSPLIT[0]} "${BINPATH}"; \
+      if [[ $BINPATH == *"/"* ]]; then \
+        mkdir -p "$(dirname "${BINPATH}")" ; \
+        cp ${BINSPLIT[0]} "${BINPATH}"; \
+      else \
+        cp ${BINSPLIT[0]} "/root/bin/${BINPATH}"; \
+      fi ;\
     else \
-      cp ${BINSPLIT[0]} . ; \
+      cp ${BINSPLIT[0]} /root/bin/ ; \
     fi; \
   done'
 

--- a/dockerfile/sdk/Dockerfile
+++ b/dockerfile/sdk/Dockerfile
@@ -78,15 +78,18 @@ ARG BINARIES
 ENV BINARIES_ENV ${BINARIES}
 RUN bash -c \
   'BINARIES_ARR=($BINARIES_ENV); \
-  cd /root/bin ; \
   for BINARY in "${BINARIES_ARR[@]}"; do \
     BINSPLIT=(${BINARY//:/ }) ; \
     BINPATH=${BINSPLIT[1]} ; \
     if [ ! -z "$BINPATH" ]; then \
-      mkdir -p "$(dirname "${BINPATH}")" ; \
-      cp ${BINSPLIT[0]} "${BINPATH}"; \
+      if [[ $BINPATH == *"/"* ]]; then \
+        mkdir -p "$(dirname "${BINPATH}")" ; \
+        cp ${BINSPLIT[0]} "${BINPATH}"; \
+      else \
+        cp ${BINSPLIT[0]} "/root/bin/${BINPATH}"; \
+      fi ;\
     else \
-      cp ${BINSPLIT[0]} . ; \
+      cp ${BINSPLIT[0]} /root/bin/ ; \
     fi; \
   done'
 

--- a/dockerfile/sdk/native.Dockerfile
+++ b/dockerfile/sdk/native.Dockerfile
@@ -50,15 +50,18 @@ ARG BINARIES
 ENV BINARIES_ENV ${BINARIES}
 RUN bash -c \
   'BINARIES_ARR=($BINARIES_ENV); \
-  cd /root/bin ; \
   for BINARY in "${BINARIES_ARR[@]}"; do \
     BINSPLIT=(${BINARY//:/ }) ; \
     BINPATH=${BINSPLIT[1]} ; \
     if [ ! -z "$BINPATH" ]; then \
-      mkdir -p "$(dirname "${BINPATH}")" ; \
-      cp ${BINSPLIT[0]} "${BINPATH}"; \
+      if [[ $BINPATH == *"/"* ]]; then \
+        mkdir -p "$(dirname "${BINPATH}")" ; \
+        cp ${BINSPLIT[0]} "${BINPATH}"; \
+      else \
+        cp ${BINSPLIT[0]} "/root/bin/${BINPATH}"; \
+      fi ;\
     else \
-      cp ${BINSPLIT[0]} . ; \
+      cp ${BINSPLIT[0]} /root/bin/ ; \
     fi; \
   done'
 


### PR DESCRIPTION
Chains that used a relative path to the binary from the build directory were broken by #42 

Fixes #46 