### PR TITLE
Heighliner version

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -103,7 +103,10 @@ func buildChainNodeDockerImage(
 		imageName = fmt.Sprintf("%s/%s", buildConfig.ContainerRegistry, chainConfig.Build.Name)
 	}
 
-	imageTags := []string{fmt.Sprintf("%s:%s", imageName, imageTag)}
+	imageTags := []string{
+		fmt.Sprintf("%s:%s", imageName, imageTag),
+		fmt.Sprintf("%s:%s-%s", imageName, imageTag, version),
+	}
 	if chainConfig.Latest {
 		imageTags = append(imageTags, fmt.Sprintf("%s:latest", imageName))
 	}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,3 @@
+package cmd
+
+const version = "v1.0.0"


### PR DESCRIPTION
Add published tag with heighliner image for immutable pins.

Heighliner version in `cmd/version.go` should be incremented for any changes to heighliner so that tags that include the heighliner version will be immutable.

Example:

- Heighliner publishes images after this is merged. This results in `$NAME:$VERSION` and `$NAME:$VERSION-v1.0.0` tags published for each name/version.
- Change made to a Dockerfile or heighliner build in any way. Version incremented to `v1.0.1` to accompany changes.
- Changes merged, heighliner builds and publishes new images with tags `$NAME:$VERSION` and `$NAME:$VERSION-v1.0.1`. `$NAME:$VERSION` is mutable because it is updated to the latest heighliner version (similar to `latest` tag behavior). `$NAME:$VERSION-v1.0.0` is immutable because it was published by a previous version of heighliner. It will never be overwritten.