### PR TITLE
wasmvm 1.1.0 bug

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,3 +1,3 @@
 package cmd
 
-const version = "v1.0.0"
+const version = "v1.0.1"

--- a/dockerfile/sdk/Dockerfile
+++ b/dockerfile/sdk/Dockerfile
@@ -61,6 +61,7 @@ RUN set -eux; \
     fi; \
     WASM_VERSION=$(go list -u -m all | grep github.com/CosmWasm/wasmvm | awk '{print $2}'); \
     if [ ! -z "${WASM_VERSION}" ]; then \
+      if [ "${WASM_VERSION}" = "v1.1.0" ]; then WASM_VERSION=v1.0.0; fi; \
       wget -O $LIBDIR/libwasmvm_muslc.a https://github.com/CosmWasm/wasmvm/releases/download/${WASM_VERSION}/libwasmvm_muslc.$ARCH.a; \
     fi; \
     export GOOS=linux GOARCH=$TARGETARCH CGO_ENABLED=1 LDFLAGS='-linkmode external -extldflags "-static"'; \

--- a/dockerfile/sdk/native.Dockerfile
+++ b/dockerfile/sdk/native.Dockerfile
@@ -34,6 +34,7 @@ ARG BUILD_DIR
 RUN set -eux; \
     WASM_VERSION=$(go list -u -m all | grep github.com/CosmWasm/wasmvm | awk '{print $2}'); \
     if [ ! -z "${WASM_VERSION}" ]; then \
+      if [ "${WASM_VERSION}" = "v1.1.0" ]; then WASM_VERSION=v1.0.0; fi; \
       wget -O /lib/libwasmvm_muslc.a https://github.com/CosmWasm/wasmvm/releases/download/${WASM_VERSION}/libwasmvm_muslc.$(uname -m).a; \
     fi; \
     export CGO_ENABLED=1 LDFLAGS='-linkmode external -extldflags "-static"'; \


### PR DESCRIPTION
When `github.com/CosmWasm/wasmvm` `v1.1.0` go mod is imported, `v1.0.0` of the library should be used for compilation instead due to a fatal runtime exception with library `v1.1.0`:
```
juno-1-tjjpl node fatal error: unexpected signal during runtime execution
juno-1-tjjpl node [signal SIGSEGV: segmentation violation code=0x2 addr=0x7f97dbe0f000 pc=0x1c8b8e7]
juno-1-tjjpl node
juno-1-tjjpl node runtime stack:
juno-1-tjjpl node runtime.throw({0x227f12d?, 0xfffffff4?})
juno-1-tjjpl node       runtime/panic.go:1047 +0x5d fp=0x7f97dc972a60 sp=0x7f97dc972a30 pc=0x45bbdd
juno-1-tjjpl node runtime.sigpanic()
juno-1-tjjpl node       runtime/signal_unix.go:819 +0x369 fp=0x7f97dc972ab0 sp=0x7f97dc972a60 pc=0x4726c9
juno-1-tjjpl node
juno-1-tjjpl node goroutine 1 [syscall]:
juno-1-tjjpl node runtime.cgocall(0x187a4a0, 0xc093535a28)
juno-1-tjjpl node       runtime/cgocall.go:158 +0x5c fp=0xc093535990 sp=0xc093535958 pc=0x425adc
juno-1-tjjpl node github.com/CosmWasm/wasmvm/api._C2func_execute(0x7f97dbe0e830, {0x0, 0xc0941a3140, 0x20}, {0x0, 0xc000537a00, 0xc5}, {0x0, 0xc093fe6910, 0x43}, ...)
juno-1-tjjpl node       _cgo_gotypes.go:294 +0x85 fp=0xc093535a28 sp=0xc093535990 pc=0x13d2705
juno-1-tjjpl node github.com/CosmWasm/wasmvm/api.Execute.func1({0xc0942efd80?}, {0x50?, 0xc0941a3140?, 0xc093535d18?}, {0x6c?, 0xc000537a00?, 0x1fd6f60?}, {0x0, 0xc093fe6910, 0x43}, ...)
juno-1-tjjpl node       github.com/CosmWasm/wasmvm@v1.1.0/api/lib.go:209 +0x247 fp=0xc093535bb8 sp=0xc093535a28 pc=0x13db8c7
juno-1-tjjpl node github.com/CosmWasm/wasmvm/api.Execute({0xc001e2d100?}, {0xc0941a3140?, 0x20?, 0x203025?}, {0xc000537a00?, 0x203025?, 0xc09435c200?}, {0xc093fe6910, 0x43,
```

https://github.com/CosmosContracts/juno/blob/v10.1.0/go.mod#L30
https://github.com/CosmosContracts/juno/tree/v10.1.0#L22-L24