### PR TITLE
Standalone phase 2. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ heighliner build -c gaia -v v6.0.0
 
 Docker image `heighliner/gaia:v6.0.0` will now be available in your local docker images
 
+#### Example: Cosmos SDK chain development cycle, build a local repository
+
+```bash
+cd ~/gaia-fork
+heighliner build -c gaia --local
+```
+
+Docker image `gaia:local` will be built and stored in your local docker images.
+
 #### Example: build and push the gaia v6.0.0 docker image to ghcr:
 
 ```bash

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -116,12 +116,11 @@ func dockerfileAndTag(
 				return dockerfile.SDKLocal, "local"
 			}
 			return dockerfile.SDKLocal, tagFromVersion(chainConfig.Version)
-		} else {
-			if buildConfig.UseBuildKit {
-				return getDockerfile("sdk/Dockerfile", dockerfile.SDK), tagFromVersion(chainConfig.Version)
-			}
-			return getDockerfile("sdk/native.Dockerfile", dockerfile.SDKNative), tagFromVersion(chainConfig.Version)
 		}
+		if buildConfig.UseBuildKit {
+			return getDockerfile("sdk/Dockerfile", dockerfile.SDK), tagFromVersion(chainConfig.Version)
+		}
+		return getDockerfile("sdk/native.Dockerfile", dockerfile.SDKNative), tagFromVersion(chainConfig.Version)
 	default:
 		return getDockerfile("none/Dockerfile", dockerfile.None), tagFromVersion(chainConfig.Version)
 	}

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -8,12 +8,15 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/strangelove-ventures/heighliner/docker"
+	"github.com/strangelove-ventures/heighliner/dockerfile"
 	"gopkg.in/yaml.v2"
 )
 
@@ -59,6 +62,7 @@ type HeighlinerDockerBuildConfig struct {
 	BuildKitAddr      string
 	Platform          string
 	NoCache           bool
+	NoBuildCache      bool
 }
 
 type HeighlinerQueuedChainBuilds struct {
@@ -68,26 +72,67 @@ type HeighlinerQueuedChainBuilds struct {
 func buildChainNodeDockerImage(
 	buildConfig *HeighlinerDockerBuildConfig,
 	chainConfig *ChainNodeDockerBuildConfig,
+	local bool,
 ) error {
-	var dockerfile string
+	var df []byte
 	var imageTag string
 	switch chainConfig.Build.Language {
 	case "imported":
-		dockerfile = "./dockerfile/imported"
+		df = dockerfile.Imported
 		imageTag = strings.ReplaceAll(chainConfig.Version, "/", "-")
 	case "rust":
-		dockerfile = "./dockerfile/rust"
+		df = dockerfile.Rust
 		imageTag = strings.ReplaceAll(chainConfig.Version, "/", "-")
 	case "nix":
-		dockerfile = "./dockerfile/nix"
+		if buildConfig.UseBuildKit {
+			df = dockerfile.Nix
+		} else {
+			df = dockerfile.NixNative
+		}
 		imageTag = strings.ReplaceAll(chainConfig.Version, "/", "-")
 	case "go":
-		dockerfile = "./dockerfile/sdk"
+		if local {
+			df = dockerfile.SDKLocal
+			chainConfig.Version = "local"
+		} else {
+			if buildConfig.UseBuildKit {
+				df = dockerfile.SDK
+			} else {
+				df = dockerfile.SDKNative
+			}
+		}
 		imageTag = strings.ReplaceAll(chainConfig.Version, "/", "-")
-
+	case "busybox":
+		var err error
+		df, err = os.ReadFile("dockerfile/busybox/Dockerfile")
+		if err != nil {
+			return fmt.Errorf("Unable to find busybox Dockerfile, needs to be built from root of heighliner repo")
+		}
+		imageTag = strings.ReplaceAll(chainConfig.Version, "/", "-")
 	default:
-		dockerfile = "./dockerfile/none"
+		df = dockerfile.None
 		imageTag = strings.ReplaceAll(chainConfig.Version, "/", "-")
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("error getting working directory: %w", err)
+	}
+
+	dir, err := os.MkdirTemp(cwd, "heighliner")
+	if err != nil {
+		return fmt.Errorf("error making temporary directory for dockerfile: %w", err)
+	}
+	defer os.RemoveAll(dir)
+
+	reldir, err := filepath.Rel(cwd, dir)
+	if err != nil {
+		return fmt.Errorf("error finding relative path for dockerfile working directory: %w", err)
+	}
+
+	dfilepath := filepath.Join(reldir, "Dockerfile")
+	if err := os.WriteFile(dfilepath, df, 0644); err != nil {
+		return fmt.Errorf("error writing temporary dockerfile: %w", err)
 	}
 
 	var imageName string
@@ -124,6 +169,11 @@ func buildChainNodeDockerImage(
 		repoHost = "github.com"
 	}
 
+	buildTimestamp := ""
+	if buildConfig.NoBuildCache {
+		buildTimestamp = strconv.FormatInt(time.Now().Unix(), 10)
+	}
+
 	buildArgs := map[string]string{
 		"VERSION":             chainConfig.Version,
 		"NAME":                chainConfig.Build.Name,
@@ -138,6 +188,7 @@ func buildChainNodeDockerImage(
 		"BUILD_ENV":           buildEnv,
 		"BUILD_TAGS":          buildTagsEnvVar,
 		"BUILD_DIR":           chainConfig.Build.BuildDir,
+		"BUILD_TIMESTAMP":     buildTimestamp,
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(time.Minute*180))
@@ -168,10 +219,15 @@ func buildChainNodeDockerImage(
 			buildKitOptions.Platform = buildConfig.Platform
 		}
 		buildKitOptions.NoCache = buildConfig.NoCache
-		return docker.BuildDockerImageWithBuildKit(ctx, dockerfile, imageTags, push, buildArgs, buildKitOptions)
+		if err := docker.BuildDockerImageWithBuildKit(ctx, reldir, imageTags, push, buildArgs, buildKitOptions); err != nil {
+			return err
+		}
 	} else {
-		return docker.BuildDockerImage(ctx, dockerfile, imageTags, push, buildArgs, buildConfig.NoCache)
+		if err := docker.BuildDockerImage(ctx, dfilepath, imageTags, push, buildArgs, buildConfig.NoCache); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 func queueMostRecentReleasesForChain(
@@ -222,6 +278,23 @@ func queueMostRecentReleasesForChain(
 	return nil
 }
 
+func loadChainsYaml(configFile string) error {
+	if _, err := os.Stat(configFile); err != nil {
+		return fmt.Errorf("error checking for file: %s: %w", configFile, err)
+	}
+	bz, err := os.ReadFile(configFile)
+	if err != nil {
+		return fmt.Errorf("error reading file: %s: %w", configFile, err)
+	}
+	var newChains []ChainNodeConfig
+	err = yaml.Unmarshal(bz, &newChains)
+	if err != nil {
+		return fmt.Errorf("error unmarshalling yaml from file: %s: %w", configFile, err)
+	}
+	chains = newChains
+	return nil
+}
+
 var buildCmd = &cobra.Command{
 	Use:   "build",
 	Short: "Build the docker images",
@@ -229,13 +302,31 @@ var buildCmd = &cobra.Command{
 For each tag that doesn't exist in the specified container repository,
 it will be built and pushed`,
 	Run: func(cmd *cobra.Command, args []string) {
-		containerRegistry, _ := cmd.Flags().GetString("registry")
-		fmt.Printf("Container registry: %s\n", containerRegistry)
-
 		cmdFlags := cmd.Flags()
 
+		configFile, _ := cmdFlags.GetString("file")
+		if configFile == "" {
+			// try to load a local chains.yaml, but do not panic for any error, will fall back to embedded chains.
+			cwd, err := os.Getwd()
+			if err == nil {
+				chainsYamlSearchPath := filepath.Join(cwd, "chains.yaml")
+				if err := loadChainsYaml(chainsYamlSearchPath); err != nil {
+					fmt.Printf("No config found at %s, using embedded chains. pass -f to configure config.yaml path.\n", chainsYamlSearchPath)
+				} else {
+					fmt.Printf("Loaded chains from %s\n", chainsYamlSearchPath)
+				}
+			}
+		} else {
+			// if flag is explicitly provided, panic on error since intent was to override embedded chains.
+			if err := loadChainsYaml(configFile); err != nil {
+				panic(err)
+			}
+		}
+
+		containerRegistry, _ := cmdFlags.GetString("registry")
 		chain, _ := cmdFlags.GetString("chain")
 		version, _ := cmdFlags.GetString("version")
+		org, _ := cmdFlags.GetString("org")
 		number, _ := cmdFlags.GetInt16("number")
 		skip, _ := cmdFlags.GetBool("skip")
 
@@ -243,19 +334,10 @@ it will be built and pushed`,
 		buildKitAddr, _ := cmdFlags.GetString("buildkit-addr")
 		platform, _ := cmdFlags.GetString("platform")
 		noCache, _ := cmdFlags.GetBool("no-cache")
+		noBuildCache, _ := cmdFlags.GetBool("no-build-cache")
 		latest, _ := cmdFlags.GetBool("latest")
+		local, _ := cmdFlags.GetBool("local")
 		parallel, _ := cmdFlags.GetInt16("parallel")
-
-		// Parse chains.yaml
-		dat, err := os.ReadFile("./chains.yaml")
-		if err != nil {
-			log.Fatalf("Error reading chains.yaml: %v", err)
-		}
-		chains := []ChainNodeConfig{}
-		err = yaml.Unmarshal(dat, &chains)
-		if err != nil {
-			log.Fatalf("Error parsing chains.yaml: %v", err)
-		}
 
 		buildQueue := []*HeighlinerQueuedChainBuilds{}
 		buildConfig := HeighlinerDockerBuildConfig{
@@ -265,6 +347,7 @@ it will be built and pushed`,
 			BuildKitAddr:      buildKitAddr,
 			Platform:          platform,
 			NoCache:           noCache,
+			NoBuildCache:      noBuildCache,
 		}
 
 		for _, chainNodeConfig := range chains {
@@ -273,8 +356,11 @@ it will be built and pushed`,
 			if chain != "" && chainNodeConfig.Name != chain {
 				continue
 			}
+			if org != "" {
+				chainNodeConfig.GithubOrganization = org
+			}
 			chainQueuedBuilds := HeighlinerQueuedChainBuilds{ChainConfigs: []ChainNodeDockerBuildConfig{}}
-			if version != "" {
+			if version != "" || local {
 				chainConfig := ChainNodeDockerBuildConfig{
 					Build:   chainNodeConfig,
 					Version: version,
@@ -282,7 +368,7 @@ it will be built and pushed`,
 				}
 				chainQueuedBuilds.ChainConfigs = append(chainQueuedBuilds.ChainConfigs, chainConfig)
 				buildQueue = append(buildQueue, &chainQueuedBuilds)
-				buildImages(&buildConfig, buildQueue, parallel)
+				buildImages(&buildConfig, buildQueue, parallel, local)
 				return
 			}
 			// If specific version not provided, build images for the last n releases from the chain
@@ -295,7 +381,7 @@ it will be built and pushed`,
 				buildQueue = append(buildQueue, &chainQueuedBuilds)
 			}
 		}
-		buildImages(&buildConfig, buildQueue, parallel)
+		buildImages(&buildConfig, buildQueue, parallel, false)
 	},
 }
 
@@ -321,7 +407,7 @@ func getQueueItem(queue []*HeighlinerQueuedChainBuilds, index int) *ChainNodeDoc
 	return nil
 }
 
-func buildNextImage(buildConfig *HeighlinerDockerBuildConfig, queue []*HeighlinerQueuedChainBuilds, buildIndex *int, buildIndexLock *sync.Mutex, wg *sync.WaitGroup, errors *[]error, errorsLock *sync.Mutex) {
+func buildNextImage(buildConfig *HeighlinerDockerBuildConfig, queue []*HeighlinerQueuedChainBuilds, buildIndex *int, buildIndexLock *sync.Mutex, wg *sync.WaitGroup, errors *[]error, errorsLock *sync.Mutex, local bool) {
 	buildIndexLock.Lock()
 	defer buildIndexLock.Unlock()
 	chainConfig := getQueueItem(queue, *buildIndex)
@@ -332,17 +418,16 @@ func buildNextImage(buildConfig *HeighlinerDockerBuildConfig, queue []*Heighline
 	}
 	go func() {
 		log.Printf("Building docker image: %s:%s\n", chainConfig.Build.Name, chainConfig.Version)
-		if err := buildChainNodeDockerImage(buildConfig, chainConfig); err != nil {
+		if err := buildChainNodeDockerImage(buildConfig, chainConfig, local); err != nil {
 			errorsLock.Lock()
 			*errors = append(*errors, fmt.Errorf("error building docker image for %s:%s - %v\n", chainConfig.Build.Name, chainConfig.Version, err))
 			errorsLock.Unlock()
 		}
-		buildNextImage(buildConfig, queue, buildIndex, buildIndexLock, wg, errors, errorsLock)
+		buildNextImage(buildConfig, queue, buildIndex, buildIndexLock, wg, errors, errorsLock, local)
 	}()
-
 }
 
-func buildImages(buildConfig *HeighlinerDockerBuildConfig, queue []*HeighlinerQueuedChainBuilds, parallel int16) {
+func buildImages(buildConfig *HeighlinerDockerBuildConfig, queue []*HeighlinerQueuedChainBuilds, parallel int16, local bool) {
 	buildIndex := 0
 	buildIndexLock := sync.Mutex{}
 	errors := []error{}
@@ -351,7 +436,7 @@ func buildImages(buildConfig *HeighlinerDockerBuildConfig, queue []*HeighlinerQu
 	wg := sync.WaitGroup{}
 	for i := int16(0); i < parallel; i++ {
 		wg.Add(1)
-		buildNextImage(buildConfig, queue, &buildIndex, &buildIndexLock, &wg, &errors, &errorsLock)
+		buildNextImage(buildConfig, queue, &buildIndex, &buildIndexLock, &wg, &errors, &errorsLock, local)
 	}
 	wg.Wait()
 	if len(errors) > 0 {
@@ -365,16 +450,20 @@ func buildImages(buildConfig *HeighlinerDockerBuildConfig, queue []*HeighlinerQu
 func init() {
 	rootCmd.AddCommand(buildCmd)
 
+	buildCmd.PersistentFlags().StringP("file", "f", "", "chains.yaml config file path")
 	buildCmd.PersistentFlags().StringP("registry", "r", "", "Docker Container Registry for pushing images")
 	buildCmd.PersistentFlags().StringP("chain", "c", "", "Cosmos chain to build from chains.yaml")
+	buildCmd.PersistentFlags().StringP("org", "o", "", "Github organization override for building from a fork")
 	buildCmd.PersistentFlags().StringP("version", "v", "", "Github tag to build")
 	buildCmd.PersistentFlags().Int16P("number", "n", 5, "Number of releases to build per chain")
 	buildCmd.PersistentFlags().Int16("parallel", 1, "Number of docker builds to run simultaneously")
 	buildCmd.PersistentFlags().BoolP("skip", "s", false, "Skip pushing images to registry")
 	buildCmd.PersistentFlags().BoolP("latest", "l", false, "Also push latest tag (for single version build only)")
+	buildCmd.PersistentFlags().Bool("local", false, "Use local directory (not git repository)")
 
 	buildCmd.PersistentFlags().BoolP("use-buildkit", "b", false, "Use buildkit to build multi-arch images")
 	buildCmd.PersistentFlags().String("buildkit-addr", docker.BuildKitSock, "Address of the buildkit socket, can be unix, tcp, ssl")
 	buildCmd.PersistentFlags().StringP("platform", "p", docker.DefaultPlatforms, "Platforms to build")
 	buildCmd.PersistentFlags().Bool("no-cache", false, "Don't use docker cache for building")
+	buildCmd.PersistentFlags().Bool("no-build-cache", false, "Invalidate caches for clone and build.")
 }

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -340,7 +340,7 @@ it will be built and pushed`,
 			if err == nil {
 				chainsYamlSearchPath := filepath.Join(cwd, "chains.yaml")
 				if err := loadChainsYaml(chainsYamlSearchPath); err != nil {
-					fmt.Printf("No config found at %s, using embedded chains. pass -f to configure config.yaml path.\n", chainsYamlSearchPath)
+					fmt.Printf("No config found at %s, using embedded chains. pass -f to configure chains.yaml path.\n", chainsYamlSearchPath)
 				} else {
 					fmt.Printf("Loaded chains from %s\n", chainsYamlSearchPath)
 				}

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -487,6 +487,7 @@ func buildImages(buildConfig *HeighlinerDockerBuildConfig, queue []*HeighlinerQu
 
 	// Delete tmp dirs on ctrl+c
 	c := make(chan os.Signal)
+	//nolint:govet
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-c

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"log"
 	"os"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
 )
 
 var rootCmd = &cobra.Command{
@@ -15,8 +17,15 @@ This tool can generate docker images for all different release versions
 of the configured Cosmos blockchains in chains.yaml`,
 }
 
-func Execute() {
-	err := rootCmd.Execute()
+var chains []ChainNodeConfig
+
+func Execute(chainsYaml []byte) {
+	err := yaml.Unmarshal(chainsYaml, &chains)
+	if err != nil {
+		log.Fatalf("Error parsing chains.yaml: %v", err)
+	}
+
+	err = rootCmd.Execute()
 	if err != nil {
 		os.Exit(1)
 	}

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"os"
 	"strings"
 
 	"github.com/docker/docker/api/types"
@@ -31,7 +30,7 @@ type DockerImageBuildLog struct {
 	ErrorDetail *DockerImageBuildErrorDetail `json:"errorDetail"`
 }
 
-func BuildDockerImage(ctx context.Context, dockerfileDir string, tags []string, push bool, args map[string]string, noCache bool) error {
+func BuildDockerImage(ctx context.Context, dockerfile string, tags []string, push bool, args map[string]string, noCache bool) error {
 	dockerClient, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		return err
@@ -42,11 +41,6 @@ func BuildDockerImage(ctx context.Context, dockerfileDir string, tags []string, 
 	for arg, value := range args {
 		thisValue := value
 		buildArgs[arg] = &thisValue
-	}
-
-	dockerfile := fmt.Sprintf("%s/native.Dockerfile", dockerfileDir)
-	if _, err := os.Stat(dockerfile); errors.Is(err, os.ErrNotExist) {
-		dockerfile = fmt.Sprintf("%s/Dockerfile", dockerfileDir)
 	}
 
 	opts := types.ImageBuildOptions{

--- a/dockerfile/dockerfiles.go
+++ b/dockerfile/dockerfiles.go
@@ -11,9 +11,6 @@ var SDKNative []byte
 //go:embed sdk/local.Dockerfile
 var SDKLocal []byte
 
-//go:embed sdk-rocksdb/Dockerfile
-var SDKRocks []byte
-
 //go:embed imported/Dockerfile
 var Imported []byte
 

--- a/dockerfile/dockerfiles.go
+++ b/dockerfile/dockerfiles.go
@@ -1,0 +1,30 @@
+package dockerfile
+
+import _ "embed"
+
+//go:embed sdk/Dockerfile
+var SDK []byte
+
+//go:embed sdk/native.Dockerfile
+var SDKNative []byte
+
+//go:embed sdk/local.Dockerfile
+var SDKLocal []byte
+
+//go:embed sdk-rocksdb/Dockerfile
+var SDKRocks []byte
+
+//go:embed imported/Dockerfile
+var Imported []byte
+
+//go:embed none/Dockerfile
+var None []byte
+
+//go:embed rust/Dockerfile
+var Rust []byte
+
+//go:embed nix/Dockerfile
+var Nix []byte
+
+//go:embed nix/native.Dockerfile
+var NixNative []byte

--- a/dockerfile/sdk/local.Dockerfile
+++ b/dockerfile/sdk/local.Dockerfile
@@ -1,0 +1,110 @@
+FROM golang:1.19-alpine3.16 AS build-env
+
+RUN apk add --update --no-cache curl make git libc-dev bash gcc linux-headers eudev-dev ncurses-dev
+
+ARG TARGETARCH
+ARG BUILDARCH
+ARG GITHUB_ORGANIZATION
+ARG REPO_HOST
+ARG GITHUB_REPO
+
+WORKDIR /go/src/${REPO_HOST}/${GITHUB_ORGANIZATION}/${GITHUB_REPO}
+
+ADD . .
+
+ARG BUILD_TARGET
+ARG BUILD_ENV
+ARG BUILD_TAGS
+ARG PRE_BUILD
+ARG BUILD_DIR
+
+RUN set -eux; \
+    WASM_VERSION=$(go list -u -m all | grep github.com/CosmWasm/wasmvm | awk '{print $2}'); \
+    if [ ! -z "${WASM_VERSION}" ]; then \
+      wget -O /lib/libwasmvm_muslc.a https://github.com/CosmWasm/wasmvm/releases/download/${WASM_VERSION}/libwasmvm_muslc.$(uname -m).a; \
+    fi; \
+    export CGO_ENABLED=1 LDFLAGS='-linkmode external -extldflags "-static"'; \
+    if [ ! -z "$PRE_BUILD" ]; then sh -c "${PRE_BUILD}"; fi; \
+    if [ ! -z "$BUILD_TARGET" ]; then \
+      if [ ! -z "$BUILD_ENV" ]; then export ${BUILD_ENV}; fi; \
+      if [ ! -z "$BUILD_TAGS" ]; then export "${BUILD_TAGS}"; fi; \
+      if [ ! -z "$BUILD_DIR" ]; then cd "${BUILD_DIR}"; fi; \
+      make ${BUILD_TARGET}; \
+    fi
+
+# Copy all binaries to /root/bin, for a single place to copy into final image.
+# If a colon (:) delimiter is present, binary will be renamed to the text after the delimiter.
+RUN mkdir /root/bin
+ARG BINARIES
+ENV BINARIES_ENV ${BINARIES}
+RUN bash -c \
+  'BINARIES_ARR=($BINARIES_ENV); \
+  for BINARY in "${BINARIES_ARR[@]}"; do \
+    BINSPLIT=(${BINARY//:/ }) ; \
+    BINPATH=${BINSPLIT[1]} ; \
+    if [ ! -z "$BINPATH" ]; then \
+      if [[ $BINPATH == *"/"* ]]; then \
+        mkdir -p "$(dirname "${BINPATH}")" ; \
+        cp ${BINSPLIT[0]} "${BINPATH}"; \
+      else \
+        cp ${BINSPLIT[0]} "/root/bin/${BINPATH}"; \
+      fi ;\
+    else \
+      cp ${BINSPLIT[0]} /root/bin/ ; \
+    fi; \
+  done'
+
+RUN mkdir -p /root/lib
+ARG LIBRARIES
+ENV LIBRARIES_ENV ${LIBRARIES}
+RUN bash -c 'LIBRARIES_ARR=($LIBRARIES_ENV); for LIBRARY in "${LIBRARIES_ARR[@]}"; do cp $LIBRARY /root/lib/; done'
+
+# Use minimal busybox from infra-toolkit image for final scratch image
+FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.0.6 AS busybox-min
+RUN addgroup --gid 1025 -S heighliner && adduser --uid 1025 -S heighliner -G heighliner
+
+# Use ln and rm from full featured busybox for assembling final image
+FROM busybox:1.34.1-musl AS busybox-full
+
+# Build final image from scratch
+FROM scratch
+
+LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/heighliner"
+
+WORKDIR /bin
+
+# Install ln (for making hard links) and rm (for cleanup) from full busybox image (will be deleted, only needed for image assembly)
+COPY --from=busybox-full /bin/ln /bin/rm ./
+
+# Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
+COPY --from=busybox-min /busybox/busybox /bin/sh
+
+# Add hard links for read-only utils, then remove ln and rm
+# Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode
+RUN ln sh pwd && \
+    ln sh ls && \
+    ln sh cat && \
+    ln sh less && \
+    ln sh grep && \
+    ln sh sleep && \
+    ln sh env && \
+    ln sh tar && \
+    ln sh tee && \
+    ln sh du && \
+    rm ln rm
+
+# Install chain binaries
+COPY --from=build-env /root/bin /bin
+
+# Install libraries
+COPY --from=build-env /root/lib /lib
+
+# Install trusted CA certificates
+COPY --from=busybox-min /etc/ssl/cert.pem /etc/ssl/cert.pem
+
+# Install heighliner user
+COPY --from=busybox-min /etc/passwd /etc/passwd
+COPY --from=busybox-min --chown=1025:1025 /home/heighliner /home/heighliner
+
+WORKDIR /home/heighliner
+USER heighliner

--- a/dockerfile/sdk/local.Dockerfile
+++ b/dockerfile/sdk/local.Dockerfile
@@ -10,6 +10,8 @@ ARG GITHUB_REPO
 
 WORKDIR /go/src/${REPO_HOST}/${GITHUB_ORGANIZATION}/${GITHUB_REPO}
 
+# This Dockerfile  is the same as native.Dockerfile except that the chain code is sourced from the
+# current working directory instead of a remote git repository.
 ADD . .
 
 ARG BUILD_TARGET

--- a/main.go
+++ b/main.go
@@ -1,7 +1,14 @@
 package main
 
-import "github.com/strangelove-ventures/heighliner/cmd"
+import (
+	_ "embed"
+
+	"github.com/strangelove-ventures/heighliner/cmd"
+)
+
+//go:embed chains.yaml
+var chainsYaml []byte
 
 func main() {
-	cmd.Execute()
+	cmd.Execute(chainsYaml)
 }


### PR DESCRIPTION
Enables heighliner standalone builds:
- Use `heighliner` bin in any working directory, does not need to find `chains.yaml` or any of the dockerfiles from the root of the repo anymore
- Adds `--local` flag which can be used for building from a local directory instead of a remote github repository. Useful for chain development cycles.

Docker requires that the Dockerfile used for building be within the build context directory. It cannot be in a parent directory or other path. To enable local builds, heighliner now has the dockerfiles embedded within the binary. It will look for the local dockerfile, but use the embedded dockerfile if it cannot be found. It will write the applicable dockerfile into a temporary directory within the local repo, then delete after build completion (success of failure).