### PR TITLE
Recursive clone in Dockerfiles, use build target for tofnd

### DIFF
--- a/chains.yaml
+++ b/chains.yaml
@@ -59,15 +59,11 @@
   github-organization: axelarnetwork
   github-repo: tofnd
   language: rust
-  pre-build: |
-    apt install -y zlib1g-dev:${TARGETARCH}
-    TOOLCHAIN=$(cat rust-toolchain.toml | grep channel | awk '{print $3}' | tr -d '"')
-    rustup component add rust-src --toolchain ${TOOLCHAIN}-$(uname -m)-unknown-linux-gnu
-    git clone https://github.com/axelarnetwork/tofnd.git --recursive
-    cd tofnd
-    cargo install --path . && cd ./target/release
+  build-target: build --release
+  pre-build:
+    apt install -y libgmp3-dev:${TARGETARCH}
   binaries:
-    - /build/tofnd/tofnd/target/release/tofnd
+    - /build/tofnd/target/${ARCH}-unknown-linux-gnu/release/tofnd
 
 # Basilisk
 - name: basilisk

--- a/dockerfile/rust/Dockerfile
+++ b/dockerfile/rust/Dockerfile
@@ -45,7 +45,7 @@ ARG GITHUB_REPO
 ARG VERSION
 ARG BUILD_TIMESTAMP
 
-RUN git clone -b ${VERSION} --single-branch https://${REPO_HOST}/${GITHUB_ORGANIZATION}/${GITHUB_REPO}.git
+RUN git clone -b ${VERSION} --single-branch https://${REPO_HOST}/${GITHUB_ORGANIZATION}/${GITHUB_REPO}.git --recursive
 
 WORKDIR /build/${GITHUB_REPO}
 

--- a/dockerfile/rust/native.Dockerfile
+++ b/dockerfile/rust/native.Dockerfile
@@ -85,8 +85,6 @@ RUN bash -c \
     done; \
   done'
 
-RUN ls /build/tofnd/target/release
-
 RUN mkdir -p /root/lib
 ARG LIBRARIES
 ENV LIBRARIES_ENV ${LIBRARIES}

--- a/dockerfile/rust/native.Dockerfile
+++ b/dockerfile/rust/native.Dockerfile
@@ -20,7 +20,7 @@ ARG GITHUB_REPO
 ARG VERSION
 ARG BUILD_TIMESTAMP
 
-RUN git clone -b ${VERSION} --single-branch https://${REPO_HOST}/${GITHUB_ORGANIZATION}/${GITHUB_REPO}.git
+RUN git clone -b ${VERSION} --single-branch https://${REPO_HOST}/${GITHUB_ORGANIZATION}/${GITHUB_REPO}.git --recursive
 
 WORKDIR /build/${GITHUB_REPO}
 
@@ -84,6 +84,8 @@ RUN bash -c \
       ((i = i + 1)) ;\
     done; \
   done'
+
+RUN ls /build/tofnd/target/release
 
 RUN mkdir -p /root/lib
 ARG LIBRARIES

--- a/dockerfile/sdk/Dockerfile
+++ b/dockerfile/sdk/Dockerfile
@@ -20,7 +20,7 @@ ARG GITHUB_REPO
 ARG VERSION
 ARG BUILD_TIMESTAMP
 
-RUN git clone -b ${VERSION} --single-branch https://${REPO_HOST}/${GITHUB_ORGANIZATION}/${GITHUB_REPO}.git
+RUN git clone -b ${VERSION} --single-branch https://${REPO_HOST}/${GITHUB_ORGANIZATION}/${GITHUB_REPO}.git --recursive
 
 WORKDIR /go/src/${REPO_HOST}/${GITHUB_ORGANIZATION}/${GITHUB_REPO}
 

--- a/dockerfile/sdk/native.Dockerfile
+++ b/dockerfile/sdk/native.Dockerfile
@@ -15,7 +15,7 @@ ARG GITHUB_REPO
 ARG VERSION
 ARG BUILD_TIMESTAMP
 
-RUN git clone -b ${VERSION} --single-branch https://${REPO_HOST}/${GITHUB_ORGANIZATION}/${GITHUB_REPO}.git
+RUN git clone -b ${VERSION} --single-branch https://${REPO_HOST}/${GITHUB_ORGANIZATION}/${GITHUB_REPO}.git --recursive
 
 WORKDIR /go/src/${REPO_HOST}/${GITHUB_ORGANIZATION}/${GITHUB_REPO}
 


### PR DESCRIPTION
PR into @danbryan 's working branch for adding tofnd. Simplifies build to use heighliner built-in clone and build process rather than manually using pre-build. Fixes build for arm64.