### PR TITLE
optimize wasm version check

### DIFF
--- a/dockerfile/sdk/Dockerfile
+++ b/dockerfile/sdk/Dockerfile
@@ -47,7 +47,7 @@ RUN set -eux; \
         export CC=x86_64-linux-musl-gcc CXX=x86_64-linux-musl-g++; \
       fi; \
     fi; \
-    WASM_VERSION=$(go list -u -m all | grep github.com/CosmWasm/wasmvm | awk '{print $2}'); \
+    WASM_VERSION=$(go list -m all | grep github.com/CosmWasm/wasmvm | awk '{print $2}'); \
     if [ ! -z "${WASM_VERSION}" ]; then \
       wget -O $LIBDIR/libwasmvm_muslc.a https://github.com/CosmWasm/wasmvm/releases/download/${WASM_VERSION}/libwasmvm_muslc.$ARCH.a; \
     fi; \

--- a/dockerfile/sdk/local.Dockerfile
+++ b/dockerfile/sdk/local.Dockerfile
@@ -21,7 +21,7 @@ ARG PRE_BUILD
 ARG BUILD_DIR
 
 RUN set -eux; \
-    WASM_VERSION=$(go list -u -m all | grep github.com/CosmWasm/wasmvm | awk '{print $2}'); \
+    WASM_VERSION=$(go list -m all | grep github.com/CosmWasm/wasmvm | awk '{print $2}'); \
     if [ ! -z "${WASM_VERSION}" ]; then \
       wget -O /lib/libwasmvm_muslc.a https://github.com/CosmWasm/wasmvm/releases/download/${WASM_VERSION}/libwasmvm_muslc.$(uname -m).a; \
     fi; \

--- a/dockerfile/sdk/native.Dockerfile
+++ b/dockerfile/sdk/native.Dockerfile
@@ -26,7 +26,7 @@ ARG PRE_BUILD
 ARG BUILD_DIR
 
 RUN set -eux; \
-    WASM_VERSION=$(go list -u -m all | grep github.com/CosmWasm/wasmvm | awk '{print $2}'); \
+    WASM_VERSION=$(go list -m all | grep github.com/CosmWasm/wasmvm | awk '{print $2}'); \
     if [ ! -z "${WASM_VERSION}" ]; then \
       wget -O /lib/libwasmvm_muslc.a https://github.com/CosmWasm/wasmvm/releases/download/${WASM_VERSION}/libwasmvm_muslc.$(uname -m).a; \
     fi; \


### PR DESCRIPTION
Only check final versions of libs for wasm version check. This reduces the time to check for the wasm version when building the Dockerfile significantly.

https://stackoverflow.com/questions/59196227/find-version-of-a-module#answer-59244274