### PR TITLE
Remove dependency on Makefile

### DIFF
--- a/chains.yaml
+++ b/chains.yaml
@@ -30,7 +30,7 @@
   language: go
   binaries:
     - bin/axelard
-  pre-build: |
+  build-target: |
     set -eux
     apk add --update nodejs npm jq py3-pip
     git clone -b v4.3.0 --single-branch https://github.com/axelarnetwork/axelar-cgp-solidity.git
@@ -113,7 +113,6 @@
   github-organization: Switcheo
   github-repo: carbon-bootstrap
   language: rust
-  build-target:
   pre-build: |
     apt update && apt install wget build-essential jq cmake sudo -y
     wget https://github.com/google/leveldb/archive/1.23.tar.gz && \
@@ -226,8 +225,7 @@
   github-organization: cosmos
   github-repo: interchain-security
   language: go
-
-  pre-build: |
+  build-target: |
     export GOFLAGS='-buildmode=pie'
     export CGO_CPPFLAGS="-D_FORTIFY_SOURCE=2"
     export CGO_LDFLAGS="-Wl,-z,relro,-z,now -fstack-protector"
@@ -395,8 +393,7 @@
   github-organization: quasar-finance
   github-repo: interchain-query-demo
   language: go
-  pre-build: |
-    go build -ldflags "$LDFLAGS" -o build/icq ./cmd/interchain-query-demod
+  build-target: go build -ldflags "$LDFLAGS" -o build/icq ./cmd/interchain-query-demod
   binaries:
     - build/icq
 
@@ -641,8 +638,8 @@
   github-organization: sentinel-official
   github-repo: hub
   language: go
-  # Hack, using pre-build instead of build target to build
-  pre-build: |
+  # Sentinel Makefile does not consume LDFLAGS or BUILD_TAGS env vars.
+  build-target: |
     BUILD_TAGS=netgo,muslc
     LD_FLAGS="-s -w -X github.com/cosmos/cosmos-sdk/version.Name=sentinel -X github.com/cosmos/cosmos-sdk/version.AppName=sentinelhub -X github.com/cosmos/cosmos-sdk/version.Version=$(echo $(git describe --tags) | sed 's/^v//') -X github.com/cosmos/cosmos-sdk/version.Commit=$(git log -1 --format='%H') -X github.com/cosmos/cosmos-sdk/version.BuildTags=\"${BUILD_TAGS}\" -X github.com/tendermint/tendermint/version.TMCoreSemVer=$(go list -m github.com/tendermint/tendermint | sed 's:.* ::')"
     go install -mod=readonly -tags="${BUILD_TAGS}" -ldflags="$LDFLAGS ${LD_FLAGS}" ./cmd/sentinelhub

--- a/chains.yaml
+++ b/chains.yaml
@@ -8,7 +8,7 @@
   github-organization: ovrclk
   github-repo: akash
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/akash
 
@@ -17,7 +17,7 @@
   github-organization: assetmantle
   github-repo: node
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/mantleNode
   build-env:
@@ -84,7 +84,7 @@
   github-organization: BitCannaGlobal
   github-repo: bcna
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/bcnad
 
@@ -93,7 +93,7 @@
   github-organization: bitsongofficial
   github-repo: go-bitsong
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/bitsongd
 
@@ -102,7 +102,7 @@
   github-organization: cybercongress
   github-repo: go-cyber
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/cyber
   build-env:
@@ -149,7 +149,7 @@
   github-organization: cerberus-zone
   github-repo: cerberus
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/cerberusd
 
@@ -158,7 +158,7 @@
   github-organization: cheqd
   github-repo: cheqd-node
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/cheqd-noded
 
@@ -167,7 +167,7 @@
   github-organization: ChihuahuaChain
   github-repo: chihuahua
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/chihuahuad
 
@@ -176,7 +176,7 @@
   github-organization: comdex-official
   github-repo: comdex
   language: go
-  build-target: install
+  build-target: make install
   build-env:
     - BUILD_TAGS=muslc
   binaries:
@@ -214,7 +214,7 @@
   github-organization: cosmos
   github-repo: gaia
   language: go
-  build-target: install
+  build-target: make install
   build-env:
     - LEDGER_ENABLED=false
     - BUILD_TAGS=muslc
@@ -242,7 +242,7 @@
   github-organization: crescent-network
   github-repo: crescent
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/crescentd
 
@@ -251,7 +251,7 @@
   github-organization: crypto-org-chain
   github-repo: cronos
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/cronosd
 
@@ -260,7 +260,7 @@
   github-organization: crypto-org-chain
   github-repo: chain-main
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/chain-maind
 
@@ -269,7 +269,7 @@
   github-organization: Decentr-net
   github-repo: decentr
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/decentrd
 
@@ -278,7 +278,7 @@
   github-organization: desmos-labs
   github-repo: desmos
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/desmos
   build-env:
@@ -289,7 +289,7 @@
   github-organization: notional-labs
   github-repo: dig
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/digd
   build-env:
@@ -300,7 +300,7 @@
   github-organization: e-money
   github-repo: em-ledger
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/emd
 
@@ -309,7 +309,7 @@
   github-organization: tharsis
   github-repo: evmos
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/evmosd
 
@@ -318,7 +318,7 @@
   github-organization: fetchai
   github-repo: fetchd
   language: go
-  build-target: install
+  build-target: make install
   build-env:
     - BUILD_TAGS=muslc
   binaries:
@@ -329,7 +329,7 @@
   github-organization: FirmaChain
   github-repo: firmachain
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/firmachaind
 
@@ -338,7 +338,7 @@
   github-organization: Gravity-Bridge
   github-repo: Gravity-Bridge
   language: go
-  build-target: build
+  build-target: make build
   build-dir: module
   binaries:
     - module/build/gravity
@@ -348,7 +348,7 @@
   github-organization: cosmos
   github-repo: ibc-go
   language: go
-  build-target: build
+  build-target: make build
   binaries:
     - build/simd
   build-env:
@@ -359,7 +359,7 @@
   github-organization: ixofoundation
   github-repo: ixo-blockchain
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/ixod
 
@@ -386,7 +386,7 @@
   github-organization: cosmos
   github-repo: interchain-accounts-demo
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/icad
 
@@ -405,7 +405,7 @@
   github-organization: irisnet
   github-repo: irishub
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/iris
 
@@ -414,7 +414,7 @@
   github-organization: CosmosContracts
   github-repo: juno
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/junod
   build-env:
@@ -426,7 +426,7 @@
   github-organization: KiFoundation
   github-repo: ki-tools
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/kid
   build-env:
@@ -437,7 +437,7 @@
   github-organization: knstl
   github-repo: konstellation
   language: go
-  build-target: install
+  build-target: make install
   build-env:
     - BUILD_TAGS=muslc
   binaries:
@@ -448,7 +448,7 @@
   github-organization: Team-Kujira
   github-repo: core
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/kujirad
   build-env:
@@ -460,7 +460,7 @@
   github-organization: likecoin
   github-repo: likecoin-chain
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/liked
 
@@ -469,7 +469,7 @@
   github-organization: lum-network
   github-repo: chain
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/lumd
 
@@ -494,7 +494,7 @@
   github-organization: neutron-org
   github-repo: neutron
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/neutrond
   build-env:
@@ -505,7 +505,7 @@
   github-organization: NibiruChain
   github-repo: nibiru
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/nibid
   build-env:
@@ -516,7 +516,7 @@
   github-organization: OmniFlix
   github-repo: omniflixhub
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/omniflixhubd
 
@@ -525,7 +525,7 @@
   github-organization: onomyprotocol
   github-repo: onomy
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/onomyd
 
@@ -534,7 +534,7 @@
   github-organization: osmosis-labs
   github-repo: osmosis
   language: go
-  build-target: build
+  build-target: make build
   binaries:
     - build/osmosisd
   build-env:
@@ -545,7 +545,7 @@
   github-organization: medibloc
   github-repo: panacea-core
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/panacead
   build-env:
@@ -566,7 +566,7 @@
   github-organization: persistenceOne
   github-repo: persistenceCore
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/persistenceCore
 
@@ -586,7 +586,7 @@
   github-organization: provenance-io
   github-repo: provenance
   language: go
-  build-target: install
+  build-target: make install
   pre-build: |
     apk add --no-cache g++
     git clone https://github.com/edenhill/librdkafka.git
@@ -607,7 +607,7 @@
   github-organization: ingenuity-build
   github-repo: quicksilver
   language: go
-  build-target: build
+  build-target: make build
   binaries:
     - build/quicksilverd
 
@@ -616,7 +616,7 @@
   github-organization: regen-network
   github-repo: regen-ledger
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/regen
 
@@ -625,7 +625,7 @@
   github-organization: rizon-world
   github-repo: rizon
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/rizond
 
@@ -654,7 +654,7 @@
   github-organization: ShentuChain
   github-repo: shentu
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/certik
 
@@ -663,7 +663,7 @@
   github-organization: Sifchain
   github-repo: sifnode
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/sifnoded
 
@@ -672,7 +672,7 @@
   github-organization: cosmos
   github-repo: cosmos-sdk
   language: go
-  build-target: build
+  build-target: make build
   binaries:
     - build/simd
 
@@ -681,7 +681,7 @@
   github-organization: peggyjv
   github-repo: sommelier
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/sommelier
 
@@ -690,7 +690,7 @@
   github-organization: public-awesome
   github-repo: stargaze
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/starsd
   build-env:
@@ -701,7 +701,7 @@
   github-organization: iov-one
   github-repo: starnamed
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/starnamed
   build-env:
@@ -712,7 +712,7 @@
   github-organization: Stride-Labs
   github-repo: stride
   language: go
-  build-target: build
+  build-target: make build
   binaries:
     - build/strided
 
@@ -721,7 +721,7 @@
   github-organization: tendermint
   github-repo: tendermint
   language: go
-  build-target: build
+  build-target: make build
   binaries:
     - /go/src/github.com/tendermint/tendermint/build/tendermint
 
@@ -730,7 +730,7 @@
   github-organization: terra-money
   github-repo: core
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/terrad
   build-env:
@@ -742,7 +742,7 @@
   github-organization: thorchain
   github-repo: thornode
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/thornode
   pre-build: |
@@ -754,7 +754,7 @@
   github-organization: umee-network
   github-repo: umee
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/umeed
 
@@ -763,7 +763,7 @@
   github-organization: vidulum
   github-repo: mainnet
   language: go
-  build-target: install
+  build-target: make install
   binaries:
     - /go/bin/vidulumd
 
@@ -772,7 +772,7 @@
   github-organization: CosmWasm
   github-repo: wasmd
   language: go
-  build-target: build
+  build-target: make build
   binaries:
     - build/wasmd
   build-env:

--- a/dockerfile/sdk/Dockerfile
+++ b/dockerfile/sdk/Dockerfile
@@ -57,7 +57,7 @@ RUN set -eux; \
       if [ ! -z "$BUILD_ENV" ]; then export ${BUILD_ENV}; fi; \
       if [ ! -z "$BUILD_TAGS" ]; then export "${BUILD_TAGS}"; fi; \
       if [ ! -z "$BUILD_DIR" ]; then cd "${BUILD_DIR}"; fi; \
-      make ${BUILD_TARGET}; \
+      sh -c "${BUILD_TARGET}"; \
     fi
 
 

--- a/dockerfile/sdk/local.Dockerfile
+++ b/dockerfile/sdk/local.Dockerfile
@@ -31,7 +31,7 @@ RUN set -eux; \
       if [ ! -z "$BUILD_ENV" ]; then export ${BUILD_ENV}; fi; \
       if [ ! -z "$BUILD_TAGS" ]; then export "${BUILD_TAGS}"; fi; \
       if [ ! -z "$BUILD_DIR" ]; then cd "${BUILD_DIR}"; fi; \
-      make ${BUILD_TARGET}; \
+      sh -c "${BUILD_TARGET}"; \
     fi
 
 # Copy all binaries to /root/bin, for a single place to copy into final image.

--- a/dockerfile/sdk/native.Dockerfile
+++ b/dockerfile/sdk/native.Dockerfile
@@ -36,7 +36,7 @@ RUN set -eux; \
       if [ ! -z "$BUILD_ENV" ]; then export ${BUILD_ENV}; fi; \
       if [ ! -z "$BUILD_TAGS" ]; then export "${BUILD_TAGS}"; fi; \
       if [ ! -z "$BUILD_DIR" ]; then cd "${BUILD_DIR}"; fi; \
-      make ${BUILD_TARGET}; \
+      sh -c "${BUILD_TARGET}"; \
     fi
 
 # Copy all binaries to /root/bin, for a single place to copy into final image.


### PR DESCRIPTION
Allow non-make builds for SDK by requiring `build-target` to be the full build command.

This also allows multi-line `build-target` instructions, so chains that were previously configured to build everything in `pre-build` can now use `build-target`