### PR TITLE
Fix/consolidate deprecation handling

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -122,18 +122,12 @@ func rawDockerfile(
 	case DockerfileTypeImported:
 		return dockerfileEmbeddedOrLocal("imported/Dockerfile", dockerfile.Imported)
 
-	case DockerfileTypeRust:
-		// DEPRECATED
-		fallthrough
 	case DockerfileTypeCargo:
 		if useBuildKit {
 			return dockerfileEmbeddedOrLocal("cargo/Dockerfile", dockerfile.Cargo)
 		}
 		return dockerfileEmbeddedOrLocal("cargo/native.Dockerfile", dockerfile.CargoNative)
 
-	case DockerfileTypeGo:
-		// DEPRECATED
-		fallthrough
 	case DockerfileTypeCosmos:
 		if local {
 			// local builds always use embedded Dockerfile.
@@ -232,6 +226,7 @@ func (h *HeighlinerBuilder) buildChainNodeDockerImage(
 	for _, rep := range deprecationReplacements {
 		if dockerfile == rep[0] {
 			fmt.Printf("'dockerfile' value of '%s' is deprecated, please use '%s' instead\n", rep[0], rep[1])
+			dockerfile = rep[1]
 		}
 	}
 	// END DEPRECATION HANDLING


### PR DESCRIPTION
Deprecation handling for `language`/`dockerfile` with value `go` was not working properly after #85 due to this conditional:
https://github.com/strangelove-ventures/heighliner/blob/43746b6feea3a49cd297ff76c7755c5b7f0c5fa7/builder/builder.go#L312

This consolidates the deprecation handling so that the core logic only needs to concern itself with the new `DockerfileType`s 