### PR TITLE
chain config override flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,24 @@ heighliner build -c gaia --local
 
 Docker image `gaia:local` will be built and stored in your local docker images.
 
+#### Example: Build from a Github fork
+
+```bash
+cd ~/gaia-fork
+heighliner build -c gaia -o strangelove-ventures -g working_branch -t image_tag
+```
+
+Heighliner will build the `working_branch` branch from the `strangelove-ventures/gaia` github organization/repository. Docker image `gaia:image_tag` will be stored in your local docker images.
+
+#### Example: Override build target
+
+```bash
+cd ~/gaia-fork
+heighliner build -c gaia -g v8.0.0 --build-target "SOME_VAR=abc make install"
+```
+
+Heighliner will build the `v8.0.0` branch of `gaia` with extra env var at build time. Docker image `gaia:v8.0.0` will be stored in your local docker images.
+
 #### Example: build and push the gaia v6.0.0 docker image to ghcr:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -45,14 +45,15 @@ heighliner build -c gaia -o strangelove-ventures -g working_branch -t image_tag
 
 Heighliner will build the `working_branch` branch from the `strangelove-ventures/gaia` github organization/repository. Docker image `gaia:image_tag` will be stored in your local docker images.
 
-#### Example: Override build target
+#### Example: build with all overrides.
+
+Heighliner can build without a chain present in chains.yaml if the necessary flags are provided.
 
 ```bash
-cd ~/gaia-fork
-heighliner build -c gaia -g v8.0.0 --build-target "SOME_VAR=abc make install"
+heighliner build -c somegaia -o somefork --repo gaia --dockerfile cosmos --build-target "make install" --build-env "LEDGER_ENABLED=false BUILD_TAGS=muslc" --binaries "/go/bin/gaiad" -g v8.0.0 -t v8.0.0-somefork
 ```
 
-Heighliner will build the `v8.0.0` branch of `gaia` with extra env var at build time. Docker image `gaia:v8.0.0` will be stored in your local docker images.
+Docker image `somegaia:v8.0.0-somefork` will be built and stored in your local docker images.
 
 #### Example: build and push the gaia v6.0.0 docker image to ghcr:
 

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -66,6 +66,10 @@ func (h *HeighlinerBuilder) AddToQueue(chainBuilds ...HeighlinerQueuedChainBuild
 	h.queue = append(h.queue, chainBuilds...)
 }
 
+func (h *HeighlinerBuilder) QueueLen() int {
+	return len(h.queue)
+}
+
 // imageTag determines which docker image tag to use based on inputs.
 func imageTag(ref string, tag string, local bool) string {
 	if tag != "" {

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -19,8 +19,13 @@ const (
 	flagRepo         = "repo"
 	flagRepoHost     = "repo-host"
 	flagGitRef       = "git-ref"
+	flagDockerfile   = "dockerfile"
+	flagBuildDir     = "build-dir"
+	flagPreBuild     = "pre-build"
 	flagBuildTarget  = "build-target"
 	flagBuildEnv     = "build-env"
+	flagBinaries     = "binaries"
+	flagLibraries    = "libraries"
 	flagTag          = "tag"
 	flagVersion      = "version" // DEPRECATED
 	flagNumber       = "number"
@@ -88,8 +93,13 @@ it will be built and pushed`,
 		org, _ := cmdFlags.GetString(flagOrg)
 		repo, _ := cmdFlags.GetString(flagRepo)
 		repoHost, _ := cmdFlags.GetString(flagRepoHost)
+		dockerfile, _ := cmdFlags.GetString(flagDockerfile)
+		buildDir, _ := cmdFlags.GetString(flagBuildDir)
+		preBuild, _ := cmdFlags.GetString(flagPreBuild)
 		buildTarget, _ := cmdFlags.GetString(flagBuildTarget)
 		buildEnv, _ := cmdFlags.GetString(flagBuildEnv)
+		binaries, _ := cmdFlags.GetString(flagBinaries)
+		libraries, _ := cmdFlags.GetString(flagLibraries)
 		number, _ := cmdFlags.GetInt16(flagNumber)
 		skip, _ := cmdFlags.GetBool(flagSkip)
 
@@ -124,7 +134,9 @@ An optional flag --tag/-t is now available to override the resulting docker imag
 		}
 		// END DEPRECATION HANDLING
 
-		queueAndBuild(buildConfig, chain, org, repo, repoHost, buildTarget, buildEnv, ref, tag, latest, local, number, parallel)
+		queueAndBuild(buildConfig, chain, org, repo, repoHost,
+			dockerfile, buildDir, preBuild, buildTarget, buildEnv,
+			binaries, libraries, ref, tag, latest, local, number, parallel)
 	},
 }
 
@@ -138,8 +150,13 @@ func init() {
 	buildCmd.PersistentFlags().String(flagRepo, "", "Git repo override for building from a fork")
 	buildCmd.PersistentFlags().String(flagRepoHost, "", "Git repository host override for building from a fork")
 	buildCmd.PersistentFlags().StringP(flagGitRef, "g", "", "Github short ref to build (branch, tag)")
+	buildCmd.PersistentFlags().String(flagDockerfile, "", "dockerfile override (cosmos, cargo, imported, none)")
+	buildCmd.PersistentFlags().String(flagBuildDir, "", "build-dir override - repo relative directory to run build target")
+	buildCmd.PersistentFlags().String(flagPreBuild, "", "pre-build override - command(s) to run prior to build-target")
 	buildCmd.PersistentFlags().String(flagBuildTarget, "", "Build target (build-target) override")
-	buildCmd.PersistentFlags().String(flagBuildEnv, "", "Build environment variables (build-env) override")
+	buildCmd.PersistentFlags().String(flagBuildEnv, "", "build-env override - Build environment variables")
+	buildCmd.PersistentFlags().String(flagBinaries, "", "binaries override - Binaries after build phase to package into final image")
+	buildCmd.PersistentFlags().String(flagLibraries, "", "libraries override - Libraries after build phase to package into final image")
 	buildCmd.PersistentFlags().StringP(flagTag, "t", "", "Resulting docker image tag. If not provided, will derive from ref.")
 	buildCmd.PersistentFlags().Int16P(flagNumber, "n", 5, "Number of releases to build per chain")
 	buildCmd.PersistentFlags().Int16(flagParallel, 1, "Number of docker builds to run simultaneously")

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -17,6 +17,7 @@ const (
 	flagChain        = "chain"
 	flagOrg          = "org"
 	flagGitRef       = "git-ref"
+	flagBuildTarget  = "build-target"
 	flagTag          = "tag"
 	flagVersion      = "version" // DEPRECATED
 	flagNumber       = "number"
@@ -82,6 +83,7 @@ it will be built and pushed`,
 		ref, _ := cmdFlags.GetString(flagGitRef)
 		tag, _ := cmdFlags.GetString(flagTag)
 		org, _ := cmdFlags.GetString(flagOrg)
+		buildTarget, _ := cmdFlags.GetString(flagBuildTarget)
 		number, _ := cmdFlags.GetInt16(flagNumber)
 		skip, _ := cmdFlags.GetBool(flagSkip)
 
@@ -116,7 +118,7 @@ An optional flag --tag/-t is now available to override the resulting docker imag
 		}
 		// END DEPRECATION HANDLING
 
-		queueAndBuild(buildConfig, chain, org, ref, tag, latest, local, number, parallel)
+		queueAndBuild(buildConfig, chain, org, buildTarget, ref, tag, latest, local, number, parallel)
 	},
 }
 
@@ -128,6 +130,7 @@ func init() {
 	buildCmd.PersistentFlags().StringP(flagChain, "c", "", "Cosmos chain to build from chains.yaml")
 	buildCmd.PersistentFlags().StringP(flagOrg, "o", "", "Github organization override for building from a fork")
 	buildCmd.PersistentFlags().StringP(flagGitRef, "g", "", "Github short ref to build (branch, tag)")
+	buildCmd.PersistentFlags().String(flagBuildTarget, "", "Build target override")
 	buildCmd.PersistentFlags().StringP(flagTag, "t", "", "Resulting docker image tag. If not provided, will derive from ref.")
 	buildCmd.PersistentFlags().Int16P(flagNumber, "n", 5, "Number of releases to build per chain")
 	buildCmd.PersistentFlags().Int16(flagParallel, 1, "Number of docker builds to run simultaneously")

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -16,8 +16,11 @@ const (
 	flagRegistry     = "registry"
 	flagChain        = "chain"
 	flagOrg          = "org"
+	flagRepo         = "repo"
+	flagRepoHost     = "repo-host"
 	flagGitRef       = "git-ref"
 	flagBuildTarget  = "build-target"
+	flagBuildEnv     = "build-env"
 	flagTag          = "tag"
 	flagVersion      = "version" // DEPRECATED
 	flagNumber       = "number"
@@ -83,7 +86,10 @@ it will be built and pushed`,
 		ref, _ := cmdFlags.GetString(flagGitRef)
 		tag, _ := cmdFlags.GetString(flagTag)
 		org, _ := cmdFlags.GetString(flagOrg)
+		repo, _ := cmdFlags.GetString(flagRepo)
+		repoHost, _ := cmdFlags.GetString(flagRepoHost)
 		buildTarget, _ := cmdFlags.GetString(flagBuildTarget)
+		buildEnv, _ := cmdFlags.GetString(flagBuildEnv)
 		number, _ := cmdFlags.GetInt16(flagNumber)
 		skip, _ := cmdFlags.GetBool(flagSkip)
 
@@ -118,7 +124,7 @@ An optional flag --tag/-t is now available to override the resulting docker imag
 		}
 		// END DEPRECATION HANDLING
 
-		queueAndBuild(buildConfig, chain, org, buildTarget, ref, tag, latest, local, number, parallel)
+		queueAndBuild(buildConfig, chain, org, repo, repoHost, buildTarget, buildEnv, ref, tag, latest, local, number, parallel)
 	},
 }
 
@@ -129,8 +135,11 @@ func init() {
 	buildCmd.PersistentFlags().StringP(flagRegistry, "r", "", "Docker Container Registry for pushing images")
 	buildCmd.PersistentFlags().StringP(flagChain, "c", "", "Cosmos chain to build from chains.yaml")
 	buildCmd.PersistentFlags().StringP(flagOrg, "o", "", "Github organization override for building from a fork")
+	buildCmd.PersistentFlags().String(flagRepo, "", "Git repo override for building from a fork")
+	buildCmd.PersistentFlags().String(flagRepoHost, "", "Git repository host override for building from a fork")
 	buildCmd.PersistentFlags().StringP(flagGitRef, "g", "", "Github short ref to build (branch, tag)")
-	buildCmd.PersistentFlags().String(flagBuildTarget, "", "Build target override")
+	buildCmd.PersistentFlags().String(flagBuildTarget, "", "Build target (build-target) override")
+	buildCmd.PersistentFlags().String(flagBuildEnv, "", "Build environment variables (build-env) override")
 	buildCmd.PersistentFlags().StringP(flagTag, "t", "", "Resulting docker image tag. If not provided, will derive from ref.")
 	buildCmd.PersistentFlags().Int16P(flagNumber, "n", 5, "Number of releases to build per chain")
 	buildCmd.PersistentFlags().Int16(flagParallel, 1, "Number of docker builds to run simultaneously")

--- a/cmd/queue.go
+++ b/cmd/queue.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/strangelove-ventures/heighliner/builder"
@@ -69,7 +70,10 @@ func queueAndBuild(
 	buildConfig builder.HeighlinerDockerBuildConfig,
 	chain string,
 	org string,
+	repo string,
+	repoHost string,
 	buildTarget string,
+	buildEnv string,
 	ref string,
 	tag string,
 	latest bool,
@@ -88,8 +92,17 @@ func queueAndBuild(
 		if org != "" {
 			chainNodeConfig.GithubOrganization = org
 		}
+		if repo != "" {
+			chainNodeConfig.GithubRepo = repo
+		}
+		if repoHost != "" {
+			chainNodeConfig.RepoHost = repoHost
+		}
 		if buildTarget != "" {
 			chainNodeConfig.BuildTarget = buildTarget
+		}
+		if buildEnv != "" {
+			chainNodeConfig.BuildEnv = strings.Split(buildEnv, " ")
 		}
 		chainQueuedBuilds := builder.HeighlinerQueuedChainBuilds{ChainConfigs: []builder.ChainNodeDockerBuildConfig{}}
 		if ref != "" || local {

--- a/cmd/queue.go
+++ b/cmd/queue.go
@@ -69,6 +69,7 @@ func queueAndBuild(
 	buildConfig builder.HeighlinerDockerBuildConfig,
 	chain string,
 	org string,
+	buildTarget string,
 	ref string,
 	tag string,
 	latest bool,
@@ -86,6 +87,9 @@ func queueAndBuild(
 		}
 		if org != "" {
 			chainNodeConfig.GithubOrganization = org
+		}
+		if buildTarget != "" {
+			chainNodeConfig.BuildTarget = buildTarget
 		}
 		chainQueuedBuilds := builder.HeighlinerQueuedChainBuilds{ChainConfigs: []builder.ChainNodeDockerBuildConfig{}}
 		if ref != "" || local {


### PR DESCRIPTION
Allows overriding all of the chains.yaml parameters.

This makes it possible to override params without needing to modify chains.yaml, or build chains that aren't present in chains.yaml if all necessary flags are provided.

Resolves #45 