### PR TITLE
docs: Remove Onomy special note

### DIFF
--- a/chains.yaml
+++ b/chains.yaml
@@ -565,9 +565,6 @@
   github-organization: onomyprotocol
   github-repo: onomy
   dockerfile: cosmos
-  # TODO: Heighliner will not produce working builds until https://github.com/onomyprotocol/onomy/pull/129 merged.
-  # If PR not merged for your git-ref, then update and push to our fork, https://github.com/strangelove-ventures/onomy, with Onomy upstream.
-  # And manually run heighliner command with `-o strangelove-ventures --git-ref main --tag <semver>`.
   build-target: make install
   binaries:
     - /go/bin/onomyd


### PR DESCRIPTION
Onomy merged the PR mentioned in the note. Builds should now work as intended. 