### PR TITLE
Github releases API auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,11 @@ heighliner will fetch the last 3 osmosis release tags from github, build docker 
 
 #### Example: build and push last n releases of all chains
 
+This will make a request to each chain's Github repository to fetch all recent releases. Github rate-limits unauthenticated requests to 60 requests per hour. Authenticated requests have either 1000 (personal) or 15000 (enterprise) per hour. To add Github API authentication, set the `GH_USER` and `GH_PAT` environment variables with your Github username and Github Personal Access Token (PAT), respectively.
+
 ```bash
 # docker login ...
+export GH_USER=github_username GH_PAT=github_personal_access_token
 heighliner build -r ghcr.io/strangelove-ventures/heighliner -n 3
 ```
 

--- a/cmd/queue.go
+++ b/cmd/queue.go
@@ -1,10 +1,12 @@
 package cmd
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -34,6 +36,11 @@ func mostRecentReleasesForChain(
 		chainNodeConfig.GithubOrganization, chainNodeConfig.GithubRepo, number), http.NoBody)
 	if err != nil {
 		return builder.HeighlinerQueuedChainBuilds{}, fmt.Errorf("error building github releases request: %v", err)
+	}
+
+	githubUser, githubPAT := os.Getenv("GH_USER"), os.Getenv("GH_PAT")
+	if githubUser != "" && githubPAT != "" {
+		req.Header.Add("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(githubUser+":"+githubPAT)))
 	}
 
 	res, err := client.Do(req)


### PR DESCRIPTION
Unauthenticated requests are limited to 60 requests per hour. This increases to 1000 per hour per repo for personal accounts, and 15000 for enterprise accounts.

Adds `GH_USER` and `GH_PAT` env vars to authenticate to Github API when fetching recent releases

Resolves #47 