### PR TITLE
Optimize local.Dockerfile compile times drastically

### DIFF
--- a/dockerfile/cosmos/local.Dockerfile
+++ b/dockerfile/cosmos/local.Dockerfile
@@ -20,17 +20,82 @@ RUN set -eux; \
     fi; \
     go mod download;
 
-ARG BUILD_TARGET
-ARG BUILD_ENV
-ARG BUILD_TAGS
-ARG PRE_BUILD
-ARG BUILD_DIR
-
 RUN mkdir -p /root/lib
 ARG LIBRARIES
 ENV LIBRARIES_ENV ${LIBRARIES}
 RUN bash -c 'set -eux;\
   LIBRARIES_ARR=($LIBRARIES_ENV); for LIBRARY in "${LIBRARIES_ARR[@]}"; do cp $LIBRARY /root/lib/; done'
+
+# Use minimal busybox from infra-toolkit image for final scratch image
+FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.0.7 AS infra-toolkit
+RUN addgroup --gid 1025 -S heighliner && adduser --uid 1025 -S heighliner -G heighliner
+
+# Use ln and rm from full featured busybox for assembling final image
+FROM busybox:1.34.1-musl AS busybox-full
+
+# Build final image from scratch
+FROM scratch AS final
+
+LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/heighliner"
+
+WORKDIR /bin
+
+# Install ln (for making hard links) and rm (for cleanup) from full busybox image (will be deleted, only needed for image assembly)
+COPY --from=busybox-full /bin/ln /bin/rm ./
+
+# Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
+COPY --from=infra-toolkit /busybox/busybox /bin/sh
+
+# Install jq
+COPY --from=infra-toolkit /usr/local/bin/jq /bin/
+
+# Add hard links for read-only utils
+# Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode
+RUN for b in \
+  cat \
+  date \
+  df \
+  du \
+  env \
+  grep \
+  head \
+  less \
+  ls \
+  md5sum \
+  pwd \
+  sha1sum \
+  sha256sum \
+  sha3sum \
+  sha512sum \
+  sleep \
+  stty \
+  tail \
+  tar \
+  tee \
+  tr \
+  watch \
+  which \
+  ; do ln sh $b; done
+
+#  Remove write utils
+RUN rm ln rm
+
+# Install trusted CA certificates
+COPY --from=infra-toolkit /etc/ssl/cert.pem /etc/ssl/cert.pem
+
+# Install heighliner user
+COPY --from=infra-toolkit /etc/passwd /etc/passwd
+COPY --from=infra-toolkit --chown=1025:1025 /home/heighliner /home/heighliner
+
+
+# Install chain binary
+FROM build-env AS build-env2
+
+ARG BUILD_TARGET
+ARG BUILD_ENV
+ARG BUILD_TAGS
+ARG PRE_BUILD
+ARG BUILD_DIR
 
 # This Dockerfile  is the same as native.Dockerfile except that the chain code is sourced from the
 # current working directory instead of a remote git repository.
@@ -80,72 +145,14 @@ RUN bash -c 'set -eux;\
     fi;\
   done'
 
-# Use minimal busybox from infra-toolkit image for final scratch image
-FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.0.7 AS infra-toolkit
-RUN addgroup --gid 1025 -S heighliner && adduser --uid 1025 -S heighliner -G heighliner
-
-# Use ln and rm from full featured busybox for assembling final image
-FROM busybox:1.34.1-musl AS busybox-full
-
-# Build final image from scratch
-FROM scratch
-
-LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/heighliner"
-
+FROM final as final2
 WORKDIR /bin
 
-# Install ln (for making hard links) and rm (for cleanup) from full busybox image (will be deleted, only needed for image assembly)
-COPY --from=busybox-full /bin/ln /bin/rm ./
-
-# Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
-COPY --from=infra-toolkit /busybox/busybox /bin/sh
-
-# Install jq
-COPY --from=infra-toolkit /usr/local/bin/jq /bin/
-
-# Add hard links for read-only utils
-# Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode
-RUN for b in \
-  cat \
-  date \
-  df \
-  du \
-  env \
-  grep \
-  head \
-  less \
-  ls \
-  md5sum \
-  pwd \
-  sha1sum \
-  sha256sum \
-  sha3sum \
-  sha512sum \
-  sleep \
-  stty \
-  tail \
-  tar \
-  tee \
-  tr \
-  watch \
-  which \
-  ; do ln sh $b; done
-
-#  Remove write utils
-RUN rm ln rm
-
 # Install chain binaries
-COPY --from=build-env /root/bin /bin
+COPY --from=build-env2 /root/bin /bin
 
 # Install libraries
-COPY --from=build-env /root/lib /lib
-
-# Install trusted CA certificates
-COPY --from=infra-toolkit /etc/ssl/cert.pem /etc/ssl/cert.pem
-
-# Install heighliner user
-COPY --from=infra-toolkit /etc/passwd /etc/passwd
-COPY --from=infra-toolkit --chown=1025:1025 /home/heighliner /home/heighliner
+COPY --from=build-env2 /root/lib /lib
 
 WORKDIR /home/heighliner
 USER heighliner

--- a/dockerfile/cosmos/local.Dockerfile
+++ b/dockerfile/cosmos/local.Dockerfile
@@ -80,6 +80,13 @@ RUN bash -c 'set -eux;\
     fi;\
   done'
 
+# Use minimal busybox from infra-toolkit image for final scratch image
+FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.0.7 AS infra-toolkit
+RUN addgroup --gid 1025 -S heighliner && adduser --uid 1025 -S heighliner -G heighliner
+
+# Use ln and rm from full featured busybox for assembling final image
+FROM busybox:1.34.1-musl AS busybox-full
+
 # Build final image from scratch
 FROM scratch
 


### PR DESCRIPTION
Closes #106

# Feature
Drastically improves local Dockerfile compile time by installing all base unix binaries & libs before compiling final image.

# Reason
We are seeing 30-35+ minute docker build times on Juno with https://github.com/CosmosContracts/juno/pull/597. This is due to `ADD` being one of the first steps in the file, not allowing for any future step caching. This PR moves that to the end, and caches better. Which drastically improves compile time for testing

# Testing
```sh
go install # heighliner this PR
heighliner build -c juno --local -f ./chains.yaml # first 37/48 steps cached

cd juno
make ictest-upgrade # runs local test
```

