### PR TITLE
Add stats on cosmos/ibc versions to list command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/docker/docker v20.10.12+incompatible
 	github.com/go-git/go-billy/v5 v5.4.0
 	github.com/go-git/go-git/v5 v5.5.2
+	github.com/hashicorp/go-version v1.6.0
 	github.com/moby/buildkit v0.10.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -821,6 +821,8 @@ github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdv
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
+github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=


### PR DESCRIPTION
Sample output:

```
[...]
wasm:
  cosmos-sdk@v0.47.0
  ibc-go@v7.0.0

Summary:

  cosmos-sdk versions:
    0.1 (1)
    0.4 (1)
    0.42 (1)
    0.44 (2)
    0.45 (25)
    0.46 (9)
    0.47 (3)
    1.0 (3)
    total: 45 chains

  ibc-go versions:
    1.2 (1)
    2.0 (2)
    3.0 (2)
    3.2 (1)
    3.3 (3)
    3.4 (5)
    4.2 (7)
    4.3 (8)
    5.1 (1)
    5.2 (4)
    6.1 (3)
    7.0 (1)
    total: 38 chains
```