### PR TITLE
Target libraries - fix penumbra dns

### DIFF
--- a/addChain.md
+++ b/addChain.md
@@ -27,7 +27,7 @@ Please keep chains in alphabetical order.
 
 `libraries` -> Any extra libraries from the build environment needed in the final image.
 
-`target-libraries` -> Any extra libraries from the target image needed in the final image.
+`target-libraries` -> Any extra libraries from the target image needed in the final image (cargo Dockerfiles only).
 
 
 ## Verify Build:

--- a/addChain.md
+++ b/addChain.md
@@ -23,9 +23,11 @@ Please keep chains in alphabetical order.
 
 `build-target` -> The build command specific to the chosen `dockerfile`. For `cosmos`, likely `make install`. For `cargo`, likely `build --release`.
 
-`binaries` -> The location of where the the build target places the binarie(s). Adding a ":" after the path allows for the ability to rename the binary.
+`binaries` -> The location of the binary(ies) in the build environment after the build is complete. Adding a ":" after the path allows for the ability to rename the binary.
 
-`libraries` -> Any extra libraries need to run the binary. In additon to the binary itself, these will be copied over to the final image
+`libraries` -> Any extra libraries from the build environment needed in the final image.
+
+`target-libraries` -> Any extra libraries from the target image needed in the final image.
 
 
 ## Verify Build:

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -299,6 +299,8 @@ func (h *HeighlinerBuilder) buildChainNodeDockerImage(
 
 	libraries := strings.Join(chainConfig.Build.Libraries, " ")
 
+	targetLibraries := strings.Join(chainConfig.Build.TargetLibraries, " ")
+
 	repoHost := chainConfig.Build.RepoHost
 	if repoHost == "" {
 		repoHost = "github.com"
@@ -350,6 +352,7 @@ func (h *HeighlinerBuilder) buildChainNodeDockerImage(
 		"BUILD_TARGET":        chainConfig.Build.BuildTarget,
 		"BINARIES":            binaries,
 		"LIBRARIES":           libraries,
+		"TARGET_LIBRARIES":    targetLibraries,
 		"PRE_BUILD":           chainConfig.Build.PreBuild,
 		"BUILD_ENV":           buildEnv,
 		"BUILD_TAGS":          buildTagsEnvVar,

--- a/builder/types.go
+++ b/builder/types.go
@@ -28,6 +28,7 @@ type ChainNodeConfig struct {
 	BuildDir           string         `yaml:"build-dir"`
 	Binaries           []string       `yaml:"binaries"`
 	Libraries          []string       `yaml:"libraries"`
+	TargetLibraries    []string       `yaml:"target-libraries"`
 	PreBuild           string         `yaml:"pre-build"`
 	Platforms          []string       `yaml:"platforms"`
 	BuildEnv           []string       `yaml:"build-env"`

--- a/chains.yaml
+++ b/chains.yaml
@@ -623,6 +623,9 @@
     - /build/penumbra/target/${ARCH}-unknown-linux-gnu/release/pd
     - /build/penumbra/target/${ARCH}-unknown-linux-gnu/release/pcli
     - /build/penumbra/target/${ARCH}-unknown-linux-gnu/release/pclientd
+  target-libraries:
+    - /lib/${ARCH}-linux-gnu/libnss_dns.so.2
+    - /lib/${ARCH}-linux-gnu/libresolv.so.2
 
 # Persistence
 - name: persistence

--- a/dockerfile/cargo/Dockerfile
+++ b/dockerfile/cargo/Dockerfile
@@ -143,11 +143,16 @@ FROM busybox:1.34.1-musl AS busybox-full
 FROM rust:1-bullseye as target-arch-libs
 RUN apt update && apt install -y libssl1.1 openssl clang libstdc++6
 
+ARG TARGETARCH
+ENV TARGETARCH=$TARGETARCH
+
 # Determine shared library dependencies for both bins and libs
 COPY --from=build-env /root/bin /root/bin
 COPY --from=build-env /root/lib/* /root/bin/
 RUN mkdir -p /root/lib_abs && touch /root/lib_abs.list
 RUN bash -c 'set -eux;\
+    if [ "${TARGETARCH}" = "arm64" ]; then export ARCH=aarch64;\
+    elif [ "${TARGETARCH}" = "amd64" ]; then export ARCH=x86_64; fi;\
     i=0; for BIN in /root/bin/*; do\
     echo "Getting $(uname -m) libs for bin: $BIN";\
     readarray -t LIBS < <(ldd "$BIN");\
@@ -178,6 +183,24 @@ RUN bash -c 'set -eux;\
       fi;\
       ((i = i + 1));\
     done;\
+  done'
+
+ARG TARGET_LIBRARIES
+ENV TARGET_LIBRARIES_ENV ${TARGET_LIBRARIES}
+RUN bash -c 'set -eux;\
+  if [ "${TARGETARCH}" = "arm64" ]; then export ARCH=aarch64;\
+  elif [ "${TARGETARCH}" = "amd64" ]; then export ARCH=x86_64; fi;\
+  i=$(wc -l < /root/lib_abs.list);\
+  LIBRARIES_ARR=($TARGET_LIBRARIES_ENV); for LIBRARY in "${LIBRARIES_ARR[@]}"; do LIB="$(eval "echo "$LIBRARY"")";\
+    if cat /root/lib_abs.list | grep -x "$LIB"; then\
+      echo "Skipping $LIB, already accounted for";\
+      continue;\
+    else\
+      echo "Copying lib2: $LIB";\
+      cp -L $LIB /root/lib_abs/$i;\
+      echo $LIB >> /root/lib_abs.list;\
+      ((i = i + 1));\
+    fi;\
   done'
 
 # Build final image from scratch


### PR DESCRIPTION
Penumbra `pclientd` binary requires `libnss_dns.so.2` and `libresolv.so.2` in order to resolve DNS.

Adds `target-libraries` to config for copying libraries from the target image. 