### PR TITLE
Add Xion chain

### DIFF
--- a/chains.yaml
+++ b/chains.yaml
@@ -891,3 +891,14 @@
     - build/wasmd
   build-env:
     - BUILD_TAGS=muslc
+
+# Xion
+- name: xion
+  github-organization: burnt-labs
+  github-repo: xion
+  dockerfile: cosmos
+  build-target: make install
+  binaries:
+    - /go/bin/xiond
+  build-env:
+    - BUILD_TAGS=muslc

--- a/chains.yaml
+++ b/chains.yaml
@@ -120,17 +120,6 @@
   build-env:
     - BUILD_TAGS=muslc
     
-# Burnt
-- name: burnt
-  github-organization: burnt-labs
-  github-repo: burnt
-  dockerfile: cosmos
-  build-target: make install
-  binaries:
-    - /go/bin/burntd
-  build-env:
-    - BUILD_TAGS=muslc
-
 # Carbon
 - name: carbon
   github-organization: Switcheo


### PR DESCRIPTION
We've rebranded our network from Burnt chain to Xion for our public launch and upgraded to the latest cosmos-sdk (v0.47.0). Updating the chains manifest to reflect.