### PR TITLE
feat: add KYVE networks

### DIFF
--- a/chains.yaml
+++ b/chains.yaml
@@ -452,6 +452,17 @@
     - LEDGER_ENABLED=false
     - BUILD_TAGS=muslc
 
+# Kaon
+- name: kaon
+  github-organization: KYVENetwork
+  github-repo: chain
+  dockerfile: cosmos
+  build-target: make install
+  binaries:
+    - /go/bin/kyved
+  build-env:
+    - ENV=kaon
+
 # Kichain
 - name: kichain
   github-organization: KiFoundation
@@ -485,6 +496,17 @@
   build-env:
     - LEDGER_ENABLED=false
     - BUILD_TAGS=muslc
+
+# KYVE
+- name: kyve
+  github-organization: KYVENetwork
+  github-repo: chain
+  dockerfile: cosmos
+  build-target: make install
+  binaries:
+    - /go/bin/kyved
+  build-env:
+    - ENV=mainnet
 
 # Likecoin
 - name: likecoin


### PR DESCRIPTION
This PR adds both the Kaon (KYVE's official testnet) and KYVE networks.

We had one issue with our Makefile, which is being remedied in https://github.com/KYVENetwork/chain/pull/34, and being released as `v1.1.1`

Until this is done, you can use [`john/v1.1-heighliner`](https://github.com/KYVENetwork/chain/tree/john/v1.1-heighliner) to verify the images.