### PR TITLE
Add tmp folder to Avalanche image

### DIFF
--- a/dockerfile/avalanche/Dockerfile
+++ b/dockerfile/avalanche/Dockerfile
@@ -166,6 +166,7 @@ COPY --from=infra-toolkit /etc/ssl/cert.pem /etc/ssl/cert.pem
 # Install heighliner user
 COPY --from=infra-toolkit /etc/passwd /etc/passwd
 COPY --from=infra-toolkit --chown=1025:1025 /home/heighliner /home/heighliner
+COPY --from=infra-toolkit --chown=1025:1025 /home/heighliner /tmp
 
 WORKDIR /home/heighliner
 USER heighliner

--- a/dockerfile/avalanche/native.Dockerfile
+++ b/dockerfile/avalanche/native.Dockerfile
@@ -143,6 +143,7 @@ COPY --from=infra-toolkit /etc/ssl/cert.pem /etc/ssl/cert.pem
 # Install heighliner user
 COPY --from=infra-toolkit /etc/passwd /etc/passwd
 COPY --from=infra-toolkit --chown=1025:1025 /home/heighliner /home/heighliner
+COPY --from=infra-toolkit --chown=1025:1025 /home/heighliner /tmp
 
 WORKDIR /home/heighliner
 USER heighliner


### PR DESCRIPTION
Avalanchego writes some temporary files into `/tmp` directory. If it doesn't exist then node stops