### PR TITLE
fix: Malformed chains.yaml

### DIFF
--- a/chains.yaml
+++ b/chains.yaml
@@ -40,10 +40,9 @@
     VERSION="1.20.0" && \
     curl -sSL \
     "https://github.com/bufbuild/buf/releases/download/v${VERSION}/buf-$(uname -s)-$(uname -m)" \
--o "${BIN}/buf" && \
+    -o "${BIN}/buf" && \
     chmod +x "${BIN}/buf"
     make protob
-
 
 # Assetmantle
 - name: assetmantle


### PR DESCRIPTION
A bad chains.yaml crushes Heighliner

```
$ heighliner build -h
panic: error parsing chains.yaml: yaml: line 48: could not find expected ':'

goroutine 1 [running]:
github.com/strangelove-ventures/heighliner/cmd.Execute({0x16fa440?, 0xda41c0?, 0xc000002340?})
        /home/strangelove/heighliner/cmd/root.go:17 +0x145
main.main()
        /home/strangelove/heighliner/main.go:13 +0x2e
```