### PR TITLE
fix: Agoric build for linux/amd64

### DIFF
--- a/chains.yaml
+++ b/chains.yaml
@@ -14,6 +14,9 @@
   dockerfile: cargo
   github-organization: Agoric
   github-repo: agoric-sdk
+  # Agoric fails to build on arm64. TODO: Debug and fix for arm64.
+  platforms:
+    - linux/amd64
   build-env:
     - LEDGER_ENABLED=false
   build-target: |


### PR DESCRIPTION
Addresses https://github.com/strangelove-ventures/heighliner/issues/132

Per suggestion in the above issue. 

This is my preference, to have `heighliner build` work (even partially) without having to remember command line flags. And the comment memorializes the issue and decision in the codebase vs. hunting through PR history.