### PR TITLE
add feature to export to docker tarball

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -398,7 +398,7 @@ func (h *HeighlinerBuilder) buildChainNodeDockerImage(
 			buildKitOptions.Platform = buildCfg.Platform
 		}
 		buildKitOptions.NoCache = buildCfg.NoCache
-		if err := docker.BuildDockerImageWithBuildKit(ctx, reldir, imageTags, push, buildArgs, buildKitOptions); err != nil {
+		if err := docker.BuildDockerImageWithBuildKit(ctx, reldir, imageTags, push, buildCfg.TarExportPath, buildArgs, buildKitOptions); err != nil {
 			return err
 		}
 	} else {

--- a/builder/types.go
+++ b/builder/types.go
@@ -49,6 +49,7 @@ type ChainNodeDockerBuildConfig struct {
 type HeighlinerDockerBuildConfig struct {
 	ContainerRegistry string
 	SkipPush          bool
+	TarExportPath     string
 	UseBuildKit       bool
 	BuildKitAddr      string
 	Platform          string

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -54,6 +54,7 @@ const (
 	flagNumber       = "number"
 	flagParallel     = "parallel"
 	flagSkip         = "skip"
+	flagTarExport    = "tar-export-path"
 	flagLatest       = "latest"
 	flagLocal        = "local"
 	flagUseBuildkit  = "use-buildkit"
@@ -158,6 +159,7 @@ An optional flag --tag/-t is now available to override the resulting docker imag
 	// Docker specific flags
 	buildCmd.PersistentFlags().StringVarP(&buildConfig.ContainerRegistry, flagRegistry, "r", "", "Docker Container Registry for pushing images")
 	buildCmd.PersistentFlags().BoolVarP(&buildConfig.SkipPush, flagSkip, "s", false, "Skip pushing images to registry")
+	buildCmd.PersistentFlags().StringVar(&buildConfig.TarExportPath, flagTarExport, "", "File path to export built image as docker tarball")
 	buildCmd.PersistentFlags().BoolVarP(&buildConfig.UseBuildKit, flagUseBuildkit, "b", false, "Use buildkit to build multi-arch images")
 	buildCmd.PersistentFlags().StringVar(&buildConfig.BuildKitAddr, flagBuildkitAddr, docker.BuildKitSock, "Address of the buildkit socket, can be unix, tcp, ssl")
 	buildCmd.PersistentFlags().StringVarP(&buildConfig.Platform, flagPlatform, "p", docker.DefaultPlatforms, "Platforms to build (only applies to buildkit builds with -b)")

--- a/docker/buildkit.go
+++ b/docker/buildkit.go
@@ -72,6 +72,10 @@ func BuildDockerImageWithBuildKit(
 	exports := make([]client.ExportEntry, 1)
 
 	if tarExport != "" {
+		if len(strings.Split(buildKitOptions.Platform, ",")) > 1 {
+			return fmt.Errorf("when using tar-export-path, only one platform is supported")
+		}
+
 		exports[0] = client.ExportEntry{
 			Type: "docker",
 			Output: func(m map[string]string) (io.WriteCloser, error) {


### PR DESCRIPTION
Adding flag `--tar-export-path` will make heighliner with buildkit output to a docker-compatible tarball instead of pushing to a registry. This only works if building for a single arch.