### PR TITLE
Wasmvm version awk should pull the last field

### DIFF
--- a/dockerfile/cosmos/Dockerfile
+++ b/dockerfile/cosmos/Dockerfile
@@ -48,7 +48,7 @@ RUN set -eux;\
         export CC=x86_64-linux-musl-gcc CXX=x86_64-linux-musl-g++;\
       fi;\
     fi;\
-    WASM_VERSION=$(go list -m all | grep github.com/CosmWasm/wasmvm | awk '{print $2}');\
+    WASM_VERSION=$(go list -m all | grep github.com/CosmWasm/wasmvm | awk '{print $NF}');\
     if [ ! -z "${WASM_VERSION}" ]; then\
       wget -O $LIBDIR/libwasmvm_muslc.a https://github.com/CosmWasm/wasmvm/releases/download/${WASM_VERSION}/libwasmvm_muslc.$ARCH.a;\
     fi;\

--- a/dockerfile/cosmos/local.Dockerfile
+++ b/dockerfile/cosmos/local.Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /go/src/${REPO_HOST}/${GITHUB_ORGANIZATION}/${GITHUB_REPO}
 ADD go.mod go.sum ./
 RUN set -eux; \
     export ARCH=$(uname -m); \
-    WASM_VERSION=$(go list -m all | grep github.com/CosmWasm/wasmvm | awk '{print $2}'); \
+    WASM_VERSION=$(go list -m all | grep github.com/CosmWasm/wasmvm | awk '{print $NF}'); \
     if [ ! -z "${WASM_VERSION}" ]; then \
       wget -O /lib/libwasmvm_muslc.a https://github.com/CosmWasm/wasmvm/releases/download/${WASM_VERSION}/libwasmvm_muslc.$(uname -m).a; \
     fi; \

--- a/dockerfile/cosmos/native.Dockerfile
+++ b/dockerfile/cosmos/native.Dockerfile
@@ -28,7 +28,7 @@ ARG BUILD_DIR
 
 RUN set -eux;\
     export ARCH=$(uname -m);\
-    WASM_VERSION=$(go list -m all | grep github.com/CosmWasm/wasmvm | awk '{print $2}');\
+    WASM_VERSION=$(go list -m all | grep github.com/CosmWasm/wasmvm | awk '{print $NF}');\
     if [ ! -z "${WASM_VERSION}" ]; then\
       wget -O /lib/libwasmvm_muslc.a https://github.com/CosmWasm/wasmvm/releases/download/${WASM_VERSION}/libwasmvm_muslc.$(uname -m).a;\
     fi;\


### PR DESCRIPTION
Grabs the last field of wasmvm version grepped instead of the 2nd. This ensures a replace in go.mod will pull the correct version.

I noticed the latest osmosis builds do not work because wasmvm v1.1.1 is downloaded instead of v1.1.2. Here is the error:
Error: libwasmversion mismatch. got: 1.1.1; expected: v1.1.2

You can see the replace here along with the security advisory. For indirect dependencies, the advisory recommends using a replace, so this commit could be required for more chains following that guidance too:
https://github.com/osmosis-labs/osmosis/blob/v15.1.2/go.mod#L314