### PR TITLE
Update Provenance config to remove Kafka dependency

### DIFF
--- a/chains.yaml
+++ b/chains.yaml
@@ -801,14 +801,6 @@
   github-repo: provenance
   dockerfile: cosmos
   build-target: make install
-  pre-build: |
-    apk add --no-cache g++
-    git clone https://github.com/edenhill/librdkafka.git
-    cd librdkafka
-    git checkout v1.8.2
-    ./configure
-    make
-    make install
   binaries:
     - /go/bin/provenanced
   build-env:


### PR DESCRIPTION
Kafka is no longer required for building Provenance (thankfully).