### PR TITLE
fix for quasar

### DIFF
--- a/chains.yaml
+++ b/chains.yaml
@@ -819,7 +819,7 @@
 # Quasar
 - name: quasar
   github-organization: quasar-finance
-  github-repo: quasar-preview
+  github-repo: quasar
   dockerfile: cosmos
   build-target: make install
   binaries:


### PR DESCRIPTION
quasar is now at quasar, not quasar-preview.  github did not seem to link these, so an update to heighliner is needed