### PR TITLE
Add hyperlane agent support. Fix non-cosmos/non-avax go version lookup.

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -352,21 +352,22 @@ func (h *HeighlinerBuilder) buildChainNodeDockerImage(
 	}
 
 	var baseVersion string
-
-	modFile, err := getModFile(
-		repoHost, chainConfig.Build.GithubOrganization, chainConfig.Build.GithubRepo,
-		chainConfig.Ref, chainConfig.Build.BuildDir, h.local,
-	)
-	if err != nil {
-		return fmt.Errorf("error getting mod file: %w", err)
-	}
-
-	baseVer := baseImageForGoVersion(modFile)
-	wasmvmVersion := getWasmvmVersion(modFile)
-
+	var baseVer GoVersion
+	var wasmvmVersion string
 	race := ""
 
 	if dockerfile == DockerfileTypeCosmos || dockerfile == DockerfileTypeAvalanche {
+		modFile, err := getModFile(
+			repoHost, chainConfig.Build.GithubOrganization, chainConfig.Build.GithubRepo,
+			chainConfig.Ref, chainConfig.Build.BuildDir, h.local,
+		)
+		if err != nil {
+			return fmt.Errorf("error getting mod file: %w", err)
+		}
+
+		baseVer = baseImageForGoVersion(modFile)
+		wasmvmVersion = getWasmvmVersion(modFile)
+
 		baseVersion = GoDefaultImage // default, and fallback if go.mod parse fails
 
 		// In error case, fallback to default image
@@ -383,6 +384,18 @@ func (h *HeighlinerBuilder) buildChainNodeDockerImage(
 				imageTags[i] = imageTag + "-race"
 			}
 		}
+	} else {
+		// Try to get mod file for non-cosmos/non-avax dockerfile types.
+		// If no error, get go version, if error, continue on without go version.
+		// Agoric looks to be the only chain needing this.
+		modFile, err := getModFile(
+			repoHost, chainConfig.Build.GithubOrganization, chainConfig.Build.GithubRepo,
+			chainConfig.Ref, chainConfig.Build.BuildDir, h.local,
+		)
+		if err == nil {
+			baseVer = baseImageForGoVersion(modFile)
+		}
+
 	}
 
 	fmt.Printf("Building image from %s, resulting docker image tags: +%v\n", buildFrom, imageTags)

--- a/chains.yaml
+++ b/chains.yaml
@@ -498,6 +498,17 @@
   build-env:
     - BUILD_TAGS=muslc
 
+# hyperlane agents
+- name: hyperlane-agents
+  github-organization: hyperlane-xyz
+  github-repo: hyperlane-monorepo
+  dockerfile: cargo
+  build-dir: rust
+  build-target: cargo build --release --bin validator --bin relayer
+  binaries:
+    - /build/hyperlane-monorepo/rust/target/x86_64-unknown-linux-gnu/release/validator
+    - /build/hyperlane-monorepo/rust/target/x86_64-unknown-linux-gnu/release/relayer
+
 # hyperlane sim (for testing)
 - name: hyperlane-simd
   github-organization: strangelove-ventures

--- a/chains.yaml
+++ b/chains.yaml
@@ -504,10 +504,14 @@
   github-repo: hyperlane-monorepo
   dockerfile: cargo
   build-dir: rust
-  build-target: cargo build --release --bin validator --bin relayer
+  build-target: |
+    sed -i '/channel/c\channel = "nightly"' ../rust-toolchain
+    rustup toolchain install nightly
+    rustup component add rust-src --toolchain nightly-$(uname -m)-unknown-linux-gnu
+    cargo build --release --bin validator --bin relayer -Zbuild-std
   binaries:
-    - /build/hyperlane-monorepo/rust/target/x86_64-unknown-linux-gnu/release/validator
-    - /build/hyperlane-monorepo/rust/target/x86_64-unknown-linux-gnu/release/relayer
+    - /build/hyperlane-monorepo/rust/target/${ARCH}-unknown-linux-gnu/release/validator
+    - /build/hyperlane-monorepo/rust/target/${ARCH}-unknown-linux-gnu/release/relayer
 
 # hyperlane sim (for testing)
 - name: hyperlane-simd


### PR DESCRIPTION
The lookup now does not error if there is no go.mod. Most cargo setups do not have a go.mod.