### PR TITLE
Add SubnetEVM with IBC into Avalanche docker image

### DIFF
--- a/chains.yaml
+++ b/chains.yaml
@@ -155,7 +155,12 @@
   github-organization: ava-labs
   github-repo: avalanchego
   dockerfile: avalanche
-  build-target:
+  build-target: |
+    startTime="$(sed -n 's|.*"startTime":\([^"]*\),.*|\1|p' genesis/genesis_local.json)"
+    if [ "$(date +%s)" -gt $startTime ]; then
+      sed "s/$startTime/1690862400/g" genesis/genesis_local.json > genesis/genesis_local_tmp.json
+      mv genesis/genesis_local_tmp.json genesis/genesis_local.json
+    fi
     bash scripts/build.sh
   binaries:
     - build/avalanchego
@@ -314,7 +319,7 @@
     COMMIT=$(git log -1 --format='%H')
     LDFLAGS="$LDFLAGS -X github.com/cosmos/cosmos-sdk/version.Name=celestia-app -X github.com/cosmos/cosmos-sdk/version.AppName=celestia-appd -X github.com/cosmos/cosmos-sdk/version.Version=$VERSION -X github.com/cosmos/cosmos-sdk/version.Commit=$COMMIT"
     go install -ldflags="$LDFLAGS" ./cmd/celestia-appd
-  binaries: 
+  binaries:
     - /go/bin/celestia-appd
 
 # Celestia Node
@@ -326,7 +331,7 @@
     versioningPath="github.com/celestiaorg/celestia-node/nodebuilder/node"
     LDFLAGS="$LDFLAGS -X '${versioningPath}.buildTime=$(date)' -X '${versioningPath}.lastCommit=$(git rev-parse HEAD)' -X '${versioningPath}.semanticVersion=$(git describe --tags --dirty=-dev 2>/dev/null || git rev-parse --abbrev-ref HEAD)'"
     go install -ldflags="$LDFLAGS" ./cmd/celestia
-  binaries: 
+  binaries:
     - /go/bin/celestia
 
 # Cerberus
@@ -1209,7 +1214,7 @@
   build-target: |
     BUILD_TAGS=netgo,muslc
     LD_FLAGS="-s -w -X github.com/cosmos/cosmos-sdk/version.Name=wormchain -X github.com/cosmos/cosmos-sdk/version.Version=$(echo $(git describe --tags) | sed 's/^v//') -X github.com/cosmos/cosmos-sdk/version.Commit=$(git log -1 --format='%H') -X github.com/cosmos/cosmos-sdk/version.BuildTags=\"${BUILD_TAGS}\" -X github.com/cosmos/cosmos-sdk/version.ServerName=wormchaind"
-    go build -mod=readonly -tags="${BUILD_TAGS}" -ldflags="$LDFLAGS ${LD_FLAGS}" -o build/wormchaind cmd/wormchaind/main.go 
+    go build -mod=readonly -tags="${BUILD_TAGS}" -ldflags="$LDFLAGS ${LD_FLAGS}" -o build/wormchaind cmd/wormchaind/main.go
   build-dir: wormchain
   binaries:
     - wormchain/build/wormchaind

--- a/chains.yaml
+++ b/chains.yaml
@@ -162,9 +162,17 @@
       sed "s/$startTime/$nowTime/g" genesis/genesis_local.json > genesis/genesis_local_tmp.json
       mv genesis/genesis_local_tmp.json genesis/genesis_local.json
     fi
-  build-target: bash scripts/build.sh
+  build-target: |
+    set -eux
+    # Build AvalancheGo
+    bash scripts/build.sh
+    # Build SubnetEVM
+    git clone -b v0.5.9-ibc-v0.1.0 --single-branch https://github.com/ConsiderItDone/subnet-evm.git
+    cd subnet-evm
+    bash scripts/build.sh
   binaries:
     - build/avalanchego
+    - /go/src/github.com/ava-labs/avalanchego/build/plugins/srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy
 
 # Axelar
 - name: axelar

--- a/chains.yaml
+++ b/chains.yaml
@@ -155,13 +155,14 @@
   github-organization: ava-labs
   github-repo: avalanchego
   dockerfile: avalanche
-  build-target: |
+  pre-build: |
     startTime="$(sed -n 's|.*"startTime":\([^"]*\),.*|\1|p' genesis/genesis_local.json)"
-    if [ "$(date +%s)" -gt $startTime ]; then
-      sed "s/$startTime/1690862400/g" genesis/genesis_local.json > genesis/genesis_local_tmp.json
+    nowTime="$(date +%s)"
+    if [ $nowTime -gt $startTime ]; then
+      sed "s/$startTime/$nowTime/g" genesis/genesis_local.json > genesis/genesis_local_tmp.json
       mv genesis/genesis_local_tmp.json genesis/genesis_local.json
     fi
-    bash scripts/build.sh
+  build-target: bash scripts/build.sh
   binaries:
     - build/avalanchego
 


### PR DESCRIPTION
This PR adds SubnetEVM (with IBC) binary into docker image. This eliminates additional work to build SubnetEVM and then copy into container