### PR TITLE
Use agoric's synchetic chain image

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -120,6 +120,9 @@ func rawDockerfile(
 	case DockerfileTypeImported:
 		return dockerfileEmbeddedOrLocal("imported/Dockerfile", dockerfile.Imported)
 
+        case DockerfileTypeAgoric:
+		return dockerfileEmbeddedOrLocal("agoric/Dockerfile", dockerfile.Agoric)
+
 	case DockerfileTypeCargo:
 		if useBuildKit {
 			return dockerfileEmbeddedOrLocal("cargo/Dockerfile", dockerfile.Cargo)

--- a/builder/types.go
+++ b/builder/types.go
@@ -4,6 +4,7 @@ type DockerfileType string
 
 const (
 	DockerfileTypeCosmos    DockerfileType = "cosmos"
+	DockerfileTypeAgoric    DockerfileType = "agoric"
 	DockerfileTypeAvalanche DockerfileType = "avalanche"
 	DockerfileTypeCargo     DockerfileType = "cargo"
 	DockerfileTypeImported  DockerfileType = "imported"

--- a/chains.yaml
+++ b/chains.yaml
@@ -11,76 +11,9 @@
 
 # Agoric-sdk
 - name: agoric
-  dockerfile: cargo
-  github-organization: Agoric
-  github-repo: agoric-sdk
-  build-env:
-    - LEDGER_ENABLED=false
-  build-target: |
-    apt update && apt install -y python3 g++
-
-    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
-    export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
-    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
-    nvm install 18
-    npm i -g yarn
-
-    set -eux
-    cd golang/cosmos
-    export CGO_ENABLED=1 GOOS=linux GOARCH=${TARGETARCH} CC=${ARCH}-linux-gnu-gcc CXX=${ARCH}-linux-gnu-g++
-    COMMIT=$(git log -1 --format='%H')
-    COMMON_LDFLAGS="-X github.com/cosmos/cosmos-sdk/version.Name=agoric \
-      -X github.com/cosmos/cosmos-sdk/version.AppName=agd \
-      -X github.com/cosmos/cosmos-sdk/version.Version=$VERSION \
-      -X "github.com/cosmos/cosmos-sdk/version.BuildTags=$BUILD_TAGS" \
-      -X github.com/cosmos/cosmos-sdk/version.Commit=$COMMIT"
-
-    # Build daemon lib
-    go build -v -mod=readonly -tags "$BUILD_TAGS" -ldflags "$COMMON_LDFLAGS" -buildmode=c-shared -o build/libagcosmosdaemon.so ./cmd/libdaemon/main.go
-
-    # Build helper
-    LDFLAGS_HELPER="$COMMON_LDFLAGS -X github.com/cosmos/cosmos-sdk/version.AppName=ag-cosmos-helper"
-    go build -v -mod=readonly -tags "$BUILD_TAGS" -ldflags "$LDFLAGS_HELPER" -o ../../bin/ag-cosmos-helper ./cmd/helper
-
-    # Build agd
-    go build -v -mod=readonly -tags "$BUILD_TAGS" -ldflags "$COMMON_LDFLAGS" -o ../../bin/agd ./cmd/agd
-
-    # Build nodejs swingset kernel
-    npm install node-addon-api --legacy-peer-deps
-    export CC_host=gcc CXX_host=g++
-    GYP_DEBUG="--arch=${TARGETARCH}" make node-compile-gyp
-    # cp binding.gyp.in binding.gyp
-    # /root/.nvm/versions/node/*/lib/node_modules/npm/bin/node-gyp-bin/node-gyp configure build --arch=${TARGETARCH}
-    cd ../../packages
-    rm -rf ui-components web-components wallet-connection wallet web-components
-    cd ..
-    npm_config_arch=${TARGETARCH} yarn
-    npm_config_arch=${TARGETARCH} yarn build
-
-    # Move to final location
-    mkdir /agoric-sdk
-    mv packages node_modules bin golang /agoric-sdk
-  directories:
-    - /agoric-sdk
-    - /root/.nvm/versions/node
-  libraries:
-    - /agoric-sdk/golang/cosmos/build/libagcosmosdaemon.so
-  target-libraries:
-    - /lib/${ARCH}-linux-gnu/libdl.so.2
-    - /lib/${ARCH}-linux-gnu/libm.so.6
-    - /usr/lib/${ARCH}-linux-gnu/libstdc++.so.6
-    - /usr/lib/gcc/${ARCH}-linux-gnu/10/libgcc_s.so
-    - /lib/${ARCH}-linux-gnu/libgcc_s.so.1
-  final-image: |
-    set -eux
-    ln -s /agoric-sdk/bin/agd /bin/agd
-    ln -s /agoric-sdk/bin/ag-cosmos-helper /bin/ag-cosmos-helper
-    ln -s /agoric-sdk/packages/cosmic-swingset/bin/ag-chain-cosmos /bin/ag-chain-cosmos
-    ln -s /agoric-sdk/packages/cosmic-swingset/bin/ag-nchainz /bin/ag-nchainz
-    mkdir -p /go/src/github.com/strangelove-ventures/agoric-sdk/golang/cosmos/build /build/agoric-sdk/golang/cosmos/build
-    mv /agoric-sdk/golang/cosmos/build/libagcosmosdaemon.so /go/src/github.com/strangelove-ventures/agoric-sdk/golang/cosmos/build/
-    ln -s  /go/src/github.com/strangelove-ventures/agoric-sdk/golang/cosmos/build/libagcosmosdaemon.so /build/agoric-sdk/golang/cosmos/build/libagcosmosdaemon.so
-    ln -s /root/.nvm/versions/node/*/bin/node /bin/node
+  dockerfile: agoric
+  platforms:
+    - linux/amd64
 
 # Akash
 - name: akash

--- a/chains.yaml
+++ b/chains.yaml
@@ -231,6 +231,20 @@
   binaries:
     - /build/Basilisk-node/target/${ARCH}-unknown-linux-gnu/release/basilisk
 
+#BeraChain
+- name: berachain
+  dockerfile: none
+  pre-build: |
+    apt update -y
+    apt install -y wget libstdc++6
+    wget -qq 'https://berad-private.s3.us-east-2.amazonaws.com/berad-linux-amd64-v0.0.6-alpha?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAXIHH4ECZJT5YBQR6%2F20231228%2Fus-east-2%2Fs3%2Faws4_request&X-Amz-Date=20231228T170607Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=56ccce6310ea364bc78f4089b86749e9f642723ab49bf836dd7d544c55f120b6' -O berad
+    mv berad /usr/bin
+    chmod 555 /usr/bin/berad
+  binaries:
+    - /usr/bin/berad
+  platforms:
+    - linux/amd64
+
 # Bitcanna
 - name: bitcanna
   github-organization: BitCannaGlobal

--- a/dockerfile/agoric/Dockerfile
+++ b/dockerfile/agoric/Dockerfile
@@ -1,0 +1,22 @@
+FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.0 AS infra-toolkit
+RUN addgroup --gid 1025 -S heighliner && adduser --uid 1025 -S heighliner -G heighliner
+
+FROM ghcr.io/agoric/agoric-3-proposals:main
+
+LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/heighliner"
+
+ARG FINAL_IMAGE
+RUN if [ ! -z "$FINAL_IMAGE" ]; then sh -c "$FINAL_IMAGE"; fi
+
+# Install trusted CA certificates
+COPY --from=infra-toolkit /etc/ssl/cert.pem /etc/ssl/cert.pem
+
+# Install heighliner user
+COPY --from=infra-toolkit /etc/passwd /etc/passwd
+COPY --from=infra-toolkit --chown=1025:1025 /home/heighliner /home/heighliner
+
+ENTRYPOINT []
+CMD []
+
+WORKDIR /home/heighliner
+USER heighliner

--- a/dockerfile/dockerfiles.go
+++ b/dockerfile/dockerfiles.go
@@ -23,6 +23,9 @@ var CosmosLocalCross []byte
 //go:embed imported/Dockerfile
 var Imported []byte
 
+//go:embed agoric/Dockerfile
+var Agoric []byte
+
 //go:embed none/Dockerfile
 var None []byte
 

--- a/dockerfile/none/Dockerfile
+++ b/dockerfile/none/Dockerfile
@@ -1,4 +1,5 @@
 FROM golang:bullseye AS build-env
+# FROM ubuntu:22.04
 
 ARG PRE_BUILD
 ARG VERSION
@@ -33,6 +34,7 @@ ENV LIBRARIES_ENV ${LIBRARIES}
 RUN bash -c 'LIBRARIES_ARR=($LIBRARIES_ENV); for LIBRARY in "${LIBRARIES_ARR[@]}"; do cp $LIBRARY /root/lib/; done'
 
 FROM debian:bullseye
+# FROM ubuntu:22.04
 
 LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/heighliner"
 


### PR DESCRIPTION
This PR utilizes the Agoric chain's mainnet synthetic chain Docker image from the Agoric-3-proposals repo, rather than replicating the Agoric chain build process. This image includes all the upgrade proposals made to the agoric mainnet.

Testing was conducted using the following commands.
```
./heighliner build -c agoric -g main
docker run -it --rm --entrypoint sh agoric:main
```