### PR TITLE
Update gravity spec in chains.yaml && Update debian version of none/Dockerfile

### DIFF
--- a/chains.yaml
+++ b/chains.yaml
@@ -800,6 +800,17 @@
   binaries:
     - /go/bin/lumd
 
+# terra
+- name: terra
+  github-organization: classic-terra
+  github-repo: core
+  dockerfile: cosmos
+  build-target: make install
+  build-env:
+    - BUILD_TAGS=muslc
+  binaries:
+    - /go/bin/terrad
+
 # Mars
 - name: mars
   github-organization: mars-protocol

--- a/chains.yaml
+++ b/chains.yaml
@@ -595,13 +595,18 @@
 
 # Gravity Bridge
 - name: gravitybridge
-  github-organization: Gravity-Bridge
-  github-repo: Gravity-Bridge
-  dockerfile: cosmos
-  build-target: make build
-  build-dir: module
+  pre-build: |
+    apt update
+    sudo apt install libc6
+    wget https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/$VERSION/gravity-linux-amd64
+    chmod +x gravity-linux-amd64
+    mv gravity-linux-amd64 /usr/bin/gravity
   binaries:
-    - module/build/gravity
+    - /usr/bin/gravity
+  libraries:
+    - /lib/x86_64-linux-gnu/libc.so.6
+  platforms:
+    - linux/amd64
 
 # ibc-go sim (for testing)
 - name: ibc-go-simd

--- a/chains.yaml
+++ b/chains.yaml
@@ -603,8 +603,6 @@
     mv gravity-linux-amd64 /usr/bin/gravity
   binaries:
     - /usr/bin/gravity
-  libraries:
-    - /lib/x86_64-linux-gnu/libc.so.6
   platforms:
     - linux/amd64
 

--- a/dockerfile/none/Dockerfile
+++ b/dockerfile/none/Dockerfile
@@ -32,7 +32,7 @@ ARG LIBRARIES
 ENV LIBRARIES_ENV ${LIBRARIES}
 RUN bash -c 'LIBRARIES_ARR=($LIBRARIES_ENV); for LIBRARY in "${LIBRARIES_ARR[@]}"; do cp $LIBRARY /root/lib/; done'
 
-FROM debian:bullseye
+FROM debian:stable
 
 LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/heighliner"
 


### PR DESCRIPTION
I saw that strangelove-ventures doesn't have the gravitybridge binary after v1.10.2~ so I tried to build image for the gravitybridge after version v1.10.2.

And now it is possible.

the first Problem of GOFLAGS(-buildmode=pie) was resolved through upgrade go image tag into golang:1.21.3-alpine3.18, but It throwed command not found. 

So, I changed build process of gravity bridge into downloading pre-compiled binary.

and also I changed the version of debian image from bullseye to stable. because gravity needs upper version than debian:bullseye.



Also I checked building image is possible at version v1.10.2, v1.11.1, v1.11.2.