### PR TITLE
refactor(readme): Make README.lint conformant.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,35 @@
-# Heighliner
+[![Conforms to README.lint](https://img.shields.io/badge/README.lint-conforming-brightgreen)](https://github.com/strangelove-ventures/readme-dot-lint)
 
-Heighliner is a utility for building production-grade container images for blockchain node software, Cosmos and beyond. 
+
+🌌 Why use Heighliner?
+=============================
+
+![Heighliner photo](https://static.wikia.nocookie.net/dune/images/7/72/51mMK0akBOL._AC_SY400_-1.jpg/revision/latest)
+
+We built Heighliner to streamline the management and building of production-grade container images for blockchain node software, Cosmos and beyond.
+
+🌌🌌 Who benefits from Heighliner?
+=============================
+
+Heighliner container images are useful for anyone who's responsible for infrastructure deployments like
+
+- validator + [horcrux](https://github.com/strangelove-ventures/horcrux),
+- full nodes,
+- archive nodes,
+- end-to-end testing ([interchaintest](https://github.com/strangelove-ventures/interchaintest)),
+- and more.
+
+🌌🌌🌌 What does Heighliner do?
+=============================
 
 Heighliner images are minimally constructed from scratch images, packaging only the chain binary and a useful reduced set of busybox utilities.
 
-These container images can be used for infrastructure deployments (validator + [horcrux](https://github.com/strangelove-ventures/horcrux), full node, archive node, etc.), end-to-end testing ([interchaintest](https://github.com/strangelove-ventures/interchaintest)), and more.
-
 This repository has a CI/CD pipeline to automatically build images when new git tags are detected on the chain repos in [chains.yaml](./chains.yaml). These images are hosted as packages in the Github Container Registry (ghcr) [here](https://github.com/orgs/strangelove-ventures/packages?repo_name=heighliner)
 
-![Heighliner photo](https://static.wikia.nocookie.net/dune/images/7/72/51mMK0akBOL._AC_SY400_-1.jpg/revision/latest)
+
+
+🌌🌌🌌🌌 How do I use Heighliner?
+=============================
 
 ## Add a New Chain
 
@@ -25,13 +46,13 @@ To publish heighliner images on your chain repository and/or incorporate heighli
 If you would like to build the images yourself, heighliner is a CLI tool to help you do so.
 Download the latest [release](https://github.com/strangelove-ventures/heighliner/releases), or build it yourself with:
 
-```bash
+```shell
 go build
 ```
 
 #### Example: build the docker image for gaia v6.0.0:
 
-```bash
+```shell
 heighliner build --chain gaia --git-ref v6.0.0
 ```
 
@@ -39,7 +60,7 @@ Docker image `heighliner/gaia:v6.0.0` will now be available in your local docker
 
 #### Example: Cosmos SDK chain development cycle, build a local repository
 
-```bash
+```shell
 cd ~/gaia-fork
 heighliner build -c gaia --local
 ```
@@ -48,7 +69,7 @@ Docker image `gaia:local` will be built and stored in your local docker images.
 
 #### Example: Build from a Github fork
 
-```bash
+```shell
 cd ~/gaia-fork
 heighliner build -c gaia -o strangelove-ventures -g working_branch -t image_tag
 ```
@@ -59,7 +80,7 @@ Heighliner will build the `working_branch` branch from the `strangelove-ventures
 
 Heighliner can build without a chain present in chains.yaml if the necessary flags are provided.
 
-```bash
+```shell
 heighliner build -c somegaia -o somefork --repo gaia --dockerfile cosmos --build-target "make install" --build-env "LEDGER_ENABLED=false BUILD_TAGS=muslc" --binaries "/go/bin/gaiad" -g v8.0.0 -t v8.0.0-somefork
 ```
 
@@ -67,7 +88,7 @@ Docker image `somegaia:v8.0.0-somefork` will be built and stored in your local d
 
 #### Example: build and push the gaia v6.0.0 docker image to ghcr:
 
-```bash
+```shell
 # docker login ...
 heighliner build -r ghcr.io/strangelove-ventures/heighliner -c gaia -g v6.0.0
 ```
@@ -76,7 +97,7 @@ Docker image `ghcr.io/strangelove-ventures/heighliner/gaia:v6.0.0` will be built
 
 #### Example: build and push last n releases of osmosis chain
 
-```bash
+```shell
 # docker login ...
 heighliner build -r ghcr.io/strangelove-ventures/heighliner -c osmosis -n 3
 ```
@@ -90,7 +111,7 @@ heighliner will fetch the last 3 osmosis release tags from github, build docker 
 
 This will make a request to each chain's Github repository to fetch all recent releases. Github rate-limits unauthenticated requests to 60 requests per hour. Authenticated requests have either 1000 (personal) or 15000 (enterprise) per hour. To add Github API authentication, set the `GH_USER` and `GH_PAT` environment variables with your Github username and Github Personal Access Token (PAT), respectively.
 
-```bash
+```shell
 # docker login ...
 export GH_USER=github_username GH_PAT=github_personal_access_token
 heighliner build -r ghcr.io/strangelove-ventures/heighliner -n 3
@@ -98,9 +119,14 @@ heighliner build -r ghcr.io/strangelove-ventures/heighliner -n 3
 
 heighliner will fetch the last 3 release tags from github for all chains in [chains.yaml](./chains.yaml), build docker images, and push them.
 
+
+
+🌌🌌🌌🌌🌌 Extras
+=============================
+
 ## Cross compiling
 Depends on docker [buildkit](https://github.com/moby/buildkit). Requires `buildkitd` server to be running.
-Pass `-b` flag to use buildkit. 
+Pass `-b` flag to use buildkit.
 
 The build will look for the local buildkit unix socket by default. Change address with `--buildkit-addr` flag.
 
@@ -108,7 +134,7 @@ Customize the platform(s) to be built with the `--platform` flag.
 
 #### Example: build x64 and arm64 docker images for gaia v7.0.1:
 
-```bash
+```shell
 heighliner build -b -c gaia -g v7.0.1
 ```
 
@@ -116,7 +142,7 @@ Docker images for `heighliner/gaia:v7.0.1` will now be available in your local d
 
 #### Example: Use custom buildkit server, build x64 and arm64 docker images for gaia v7.0.1, and push:
 
-```bash
+```shell
 heighliner build -b --buildkit-addr tcp://192.168.1.5:8125 -c gaia -g v7.0.1 -r ghcr.io/strangelove-ventures/heighliner
 ```
 


### PR DESCRIPTION
README.lint offers a convention-over-configuration approach to README files, simplifying onboarding to a new tech stack.

More at https://github.com/strangelove-ventures/readme-dot-lint.