### PR TITLE
chore(provenance): add required chain build parameter

### DIFF
--- a/chains.yaml
+++ b/chains.yaml
@@ -999,6 +999,7 @@
     - /build/polkadot/target/${ARCH}-unknown-linux-gnu/release/polkadot
 
 # Provenance
+# Requires "--alpine-version 3.18" set as a flag to the build command
 - name: provenance
   github-organization: provenance-io
   github-repo: provenance


### PR DESCRIPTION
# Problem

Building on `musl` and `alpine 3.19` produces an error of [this](https://github.com/golang/go/issues/64698) form.

# Solution

Added a comment like is present for Axelar.

Seeing this problem means there's some compatibility issues that aren't great. Since this isn't defined in the yaml, the automated process that builds and pushes these images will no longer work. It also can't be added to the config either because older chain tags might need to be on alpine versions before the specified flag.

This isn't a problem for Provenance because we plan on building and pushing our own images.