### PR TITLE
feat: add `clone-key` option for private repos

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -2,6 +2,8 @@ package builder
 
 import (
 	"context"
+	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -16,6 +18,7 @@ import (
 	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	"github.com/go-git/go-git/v5/storage/memory"
 	"golang.org/x/mod/modfile"
 
@@ -151,6 +154,7 @@ func getModFile(
 	repoHost string,
 	organization string,
 	repoName string,
+	cloneKey string,
 	ref string,
 	buildDir string,
 	local bool,
@@ -177,6 +181,21 @@ func getModFile(
 		}
 		// Try as tag ref first
 		cloneOpts.ReferenceName = plumbing.NewTagReferenceName(ref)
+		// if there is a clone key, decode and use it to authenticate
+		if cloneKey != "" {
+			cloneKeyBz, err := base64.StdEncoding.DecodeString(cloneKey)
+			if err != nil {
+				return nil, errors.New("failed to decode clone key")
+			}
+
+			key, err := ssh.NewPublicKeys("git", cloneKeyBz, "")
+			if err != nil {
+				return nil, errors.New("failed to generate public key")
+			}
+
+			cloneOpts.URL = fmt.Sprintf("git@%s:%s/%s.git", repoHost, organization, repoName)
+			cloneOpts.Auth = key
+		}
 
 		// Clone into memory
 		fs := memfs.New()
@@ -353,7 +372,7 @@ func (h *HeighlinerBuilder) buildChainNodeDockerImage(
 
 	modFile, err := getModFile(
 		repoHost, chainConfig.Build.GithubOrganization, chainConfig.Build.GithubRepo,
-		chainConfig.Ref, chainConfig.Build.BuildDir, h.local,
+		chainConfig.Build.CloneKey, chainConfig.Ref, chainConfig.Build.BuildDir, h.local,
 	)
 
 	goVersion := buildCfg.GoVersion
@@ -397,6 +416,7 @@ func (h *HeighlinerBuilder) buildChainNodeDockerImage(
 		"REPO_HOST":           repoHost,
 		"GITHUB_ORGANIZATION": chainConfig.Build.GithubOrganization,
 		"GITHUB_REPO":         chainConfig.Build.GithubRepo,
+		"CLONE_KEY":           chainConfig.Build.CloneKey,
 		"BUILD_TARGET":        chainConfig.Build.BuildTarget,
 		"BINARIES":            binaries,
 		"LIBRARIES":           libraries,

--- a/builder/types.go
+++ b/builder/types.go
@@ -24,6 +24,7 @@ type ChainNodeConfig struct {
 	RepoHost           string         `yaml:"repo-host"`
 	GithubOrganization string         `yaml:"github-organization"`
 	GithubRepo         string         `yaml:"github-repo"`
+	CloneKey           string         `yaml:"clone-key"`
 	Language           DockerfileType `yaml:"language"` // DEPRECATED, use "dockerfile" instead
 	Dockerfile         DockerfileType `yaml:"dockerfile"`
 	BuildTarget        string         `yaml:"build-target"`

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -25,6 +25,7 @@ type chainConfigFlags struct {
 	orgOverride         string
 	repoOverride        string
 	repoHostOverride    string
+	cloneKeyOverride    string
 	dockerfileOverride  string
 	buildDirOverride    string
 	preBuildOverride    string
@@ -41,6 +42,7 @@ const (
 	flagOrg           = "org"
 	flagRepo          = "repo"
 	flagRepoHost      = "repo-host"
+	flagCloneKey      = "clone-key"
 	flagGitRef        = "git-ref"
 	flagDockerfile    = "dockerfile"
 	flagBuildDir      = "build-dir"
@@ -150,6 +152,7 @@ An optional flag --tag/-t is now available to override the resulting docker imag
 	buildCmd.PersistentFlags().StringVarP(&chainConfig.orgOverride, flagOrg, "o", "", "github-organization override for building from a fork")
 	buildCmd.PersistentFlags().StringVar(&chainConfig.repoOverride, flagRepo, "", "github-repo override for building from a fork")
 	buildCmd.PersistentFlags().StringVar(&chainConfig.repoHostOverride, flagRepoHost, "", "repo-host Git repository host override for building from a fork")
+	buildCmd.PersistentFlags().StringVar(&chainConfig.cloneKeyOverride, flagCloneKey, "", "base64 encoded ssh key to authenticate")
 	buildCmd.PersistentFlags().StringVar(&chainConfig.dockerfileOverride, flagDockerfile, "", "dockerfile override (cosmos, cargo, imported, none)")
 	buildCmd.PersistentFlags().StringVar(&chainConfig.buildDirOverride, flagBuildDir, "", "build-dir override - repo relative directory to run build target")
 	buildCmd.PersistentFlags().StringVar(&chainConfig.preBuildOverride, flagPreBuild, "", "pre-build override - command(s) to run prior to build-target")

--- a/cmd/queue.go
+++ b/cmd/queue.go
@@ -97,6 +97,9 @@ func queueAndBuild(
 		if chainConfig.repoHostOverride != "" {
 			chainNodeConfig.RepoHost = chainConfig.repoHostOverride
 		}
+		if chainConfig.cloneKeyOverride != "" {
+			chainNodeConfig.CloneKey = chainConfig.cloneKeyOverride
+		}
 		if chainConfig.buildTargetOverride != "" {
 			chainNodeConfig.BuildTarget = chainConfig.buildTargetOverride
 		}
@@ -139,6 +142,7 @@ func queueAndBuild(
 				RepoHost:           chainConfig.repoHostOverride,
 				GithubOrganization: chainConfig.orgOverride,
 				GithubRepo:         chainConfig.repoOverride,
+				CloneKey:           chainConfig.cloneKeyOverride,
 				Dockerfile:         builder.DockerfileType(chainConfig.dockerfileOverride),
 				PreBuild:           chainConfig.preBuildOverride,
 				BuildTarget:        chainConfig.buildTargetOverride,

--- a/dockerfile/cosmos/Dockerfile
+++ b/dockerfile/cosmos/Dockerfile
@@ -12,6 +12,17 @@ RUN if [ "${TARGETARCH}" = "arm64" ] && [ "${BUILDARCH}" != "arm64" ]; then\
         wget -c https://musl.cc/x86_64-linux-musl-cross.tgz -O - | tar -xzvv --strip-components 1 -C /usr;\
     fi
 
+ARG CLONE_KEY
+
+RUN if [ ! -z "CLONE_KEY" ]; then\
+        mkdir -p ~/.ssh;\
+        echo "${CLONE_KEY}" | base64 -d > ~/.ssh/id_ed25519;\
+        chmod 600 ~/.ssh/id_ed25519;\
+        apk add openssh;\
+        git config --global --add url."ssh://git@github.com/".insteadOf "https://github.com/";\
+        ssh-keyscan github.com >> ~/.ssh/known_hosts;\
+    fi
+
 ARG GITHUB_ORGANIZATION
 ARG REPO_HOST
 

--- a/dockerfile/cosmos/native.Dockerfile
+++ b/dockerfile/cosmos/native.Dockerfile
@@ -3,6 +3,17 @@ FROM golang:${BASE_VERSION} AS build-env
 
 RUN apk add --update --no-cache curl make git libc-dev bash gcc linux-headers eudev-dev ncurses-dev
 
+ARG CLONE_KEY
+
+RUN if [ ! -z "CLONE_KEY" ]; then\
+        mkdir -p ~/.ssh;\
+        echo "${CLONE_KEY}" | base64 -d > ~/.ssh/id_ed25519;\
+        chmod 600 ~/.ssh/id_ed25519;\
+        apk add openssh;\
+        git config --global --add url."ssh://git@github.com/".insteadOf "https://github.com/";\
+        ssh-keyscan github.com >> ~/.ssh/known_hosts;\
+    fi
+
 ARG TARGETARCH
 ARG BUILDARCH
 ARG GITHUB_ORGANIZATION


### PR DESCRIPTION
This PR adds support for a new `clone-key` option, allowing Heighliner to build private repositories.

This is useful when testing internal SimApps.

Note that this is a copy of #249, which was closed because the branch was automatically deleted.