### PR TITLE
feat: add clone-key option for local with private go modules

### DIFF
--- a/dockerfile/cosmos/local.Dockerfile
+++ b/dockerfile/cosmos/local.Dockerfile
@@ -25,6 +25,17 @@ ARG BUILD_DIR
 
 ADD ${BUILD_DIR}/go.mod ${BUILD_DIR}/go.sum ./
 
+ARG CLONE_KEY
+
+RUN if [ ! -z "${CLONE_KEY}" ]; then\
+  mkdir -p ~/.ssh;\
+  echo "${CLONE_KEY}" | base64 -d > ~/.ssh/id_ed25519;\
+  chmod 600 ~/.ssh/id_ed25519;\
+  apk add openssh;\
+  git config --global --add url."ssh://git@github.com/".insteadOf "https://github.com/";\
+  ssh-keyscan github.com >> ~/.ssh/known_hosts;\
+  fi
+
 # Download go mod dependencies, if there is no custom build directory
 # Note: a custom build dir indicates a monorepo with potential dependencies we can't anticipate atm
 RUN set -eux; \

--- a/dockerfile/cosmos/localcross.Dockerfile
+++ b/dockerfile/cosmos/localcross.Dockerfile
@@ -15,7 +15,7 @@ RUN if [ "${TARGETARCH}" = "arm64" ] && [ "${BUILDARCH}" != "arm64" ]; then\
 ARG GITHUB_ORGANIZATION
 ARG REPO_HOST
 
-WORKDIR /go/src/${REPO_HOST}/${GITHUB_ORGANIZATION}
+WORKDIR /go/src/${REPO_HOST}/${GITHUB_ORGANIZATION}/${GITHUB_REPO}
 
 ARG GITHUB_REPO
 ARG VERSION
@@ -23,14 +23,23 @@ ARG BUILD_TIMESTAMP
 
 ADD . .
 
-WORKDIR /go/src/${REPO_HOST}/${GITHUB_ORGANIZATION}/${GITHUB_REPO}
-
 ARG BUILD_TARGET
 ARG BUILD_ENV
 ARG BUILD_TAGS
 ARG PRE_BUILD
 ARG BUILD_DIR
 ARG WASMVM_VERSION
+
+ARG CLONE_KEY
+
+RUN if [ ! -z "${CLONE_KEY}" ]; then\
+  mkdir -p ~/.ssh;\
+  echo "${CLONE_KEY}" | base64 -d > ~/.ssh/id_ed25519;\
+  chmod 600 ~/.ssh/id_ed25519;\
+  apk add openssh;\
+  git config --global --add url."ssh://git@github.com/".insteadOf "https://github.com/";\
+  ssh-keyscan github.com >> ~/.ssh/known_hosts;\
+  fi
 
 RUN set -eux;\
     LIBDIR=/lib;\


### PR DESCRIPTION
It is possible that local repo can have private go modules in the go.mod, add CLONE_KEY option in local*.Dockerfile if required.
Also `WORKDIR /go/src/${REPO_HOST}/${GITHUB_ORGANIZATION}/${GITHUB_REPO}` should be created before `ADD . .`