### PR TITLE
fix: Some chains decide to name the static files differently

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Conforms to README.lint](https://img.shields.io/badge/README.lint-conforming-brightgreen)](https://github.com/strangelove-ventures/readme-dot-lint)
-
 
 🌌 Why use Heighliner?
 =============================

--- a/dockerfile/cosmos/Dockerfile
+++ b/dockerfile/cosmos/Dockerfile
@@ -65,7 +65,9 @@ RUN set -eux;\
       WASMVM_VERS=$(echo $WASMVM_VERSION | awk '{print $2}');\
       wget -O $LIBDIR/libwasmvm_muslc.a https://${WASMVM_REPO}/releases/download/${WASMVM_VERS}/libwasmvm_muslc.${ARCH}.a;\
       cp $LIBDIR/libwasmvm_muslc.a $LIBDIR/libwasmvm.x86_64.a;\
+      cp $LIBDIR/libwasmvm_muslc.a $LIBDIR/libwasmvm_muslc.x86_64.a;\ 
       cp $LIBDIR/libwasmvm_muslc.a $LIBDIR/libwasmvm.aarch64.a;\
+      cp $LIBDIR/libwasmvm_muslc.a $LIBDIR/libwasmvm_muslc.aarch64.a;\
     fi;\
     export GOOS=linux GOARCH=$TARGETARCH CGO_ENABLED=1 LDFLAGS='-linkmode external -extldflags "-static"';\
     if [ ! -z "$PRE_BUILD" ]; then sh -c "${PRE_BUILD}"; fi;\


### PR DESCRIPTION
1. Remove link to private repo that is causing a lint error.
2. Some chains name static wasm lib file's differently