### PR TITLE
chore: update latest go version `1.22.6`

### DIFF
--- a/builder/go_versions.go
+++ b/builder/go_versions.go
@@ -13,7 +13,7 @@ const (
 	Go119Version = "1.19.13"
 	Go120Version = "1.20.14"
 	Go121Version = "1.21.7"
-	Go122Version = "1.22.0"
+	Go122Version = "1.22.3"
 	// ADD NEW GO VERSION [1] - latest patch release for each major/minor
 
 	// When updating alpine image, ensure all golang build image combinations below exist

--- a/builder/go_versions.go
+++ b/builder/go_versions.go
@@ -13,7 +13,7 @@ const (
 	Go119Version = "1.19.13"
 	Go120Version = "1.20.14"
 	Go121Version = "1.21.7"
-	Go122Version = "1.22.3"
+	Go122Version = "1.22.6"
 	// ADD NEW GO VERSION [1] - latest patch release for each major/minor
 
 	// When updating alpine image, ensure all golang build image combinations below exist


### PR DESCRIPTION
Reference: https://hub.docker.com/_/golang

Note: according the above reference, we could probably get away with removing the minor version and just have `1.22` to always pull latest if we wanted to. 