### PR TITLE
fix: re-remove generate binary from build as it was removed from thornode repo

### DIFF
--- a/chains.yaml
+++ b/chains.yaml
@@ -1251,11 +1251,10 @@
     VERSION=$(cat version)
     if [ -z "$TAG" ]; then TAG=mocknet; fi
     ldflags="-X gitlab.com/thorchain/thornode/constants.Version=${VERSION} -X gitlab.com/thorchain/thornode/constants.GitCommit=${COMMIT} -X github.com/cosmos/cosmos-sdk/version.Name=THORChain -X github.com/cosmos/cosmos-sdk/version.AppName=thornode -X github.com/cosmos/cosmos-sdk/version.Version=${VERSION} -X github.com/cosmos/cosmos-sdk/version.Commit=${COMMIT} -X github.com/cosmos/cosmos-sdk/version.BuildTags=${TAG} -buildid="
-    go install -tags=$TAG -ldflags="${ldflags} $LDFLAGS" ./cmd/thornode ./cmd/bifrost ./tools/generate
+    go install -tags=$TAG -ldflags="${ldflags} $LDFLAGS" ./cmd/thornode ./cmd/bifrost
   binaries:
     - /go/bin/thornode
     - /go/bin/bifrost
-    - /go/bin/generate
   pre-build: |
     apk --no-cache add findutils protoc && \
     rm -rf /var/cache/apk/*


### PR DESCRIPTION
it appears to have been accidentially re-added in a previous pr