### PR TITLE
fix: support creating dirs for copied directories

### DIFF
--- a/dockerfile/cosmos/Dockerfile
+++ b/dockerfile/cosmos/Dockerfile
@@ -151,7 +151,7 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 WORKDIR /bin
 
 # Install ln (for making hard links) and rm (for cleanup) from full busybox image (will be deleted, only needed for image assembly)
-COPY --from=busybox-full /bin/ln /bin/mv /bin/rm ./
+COPY --from=busybox-full /bin/ln /bin/mv /bin/rm /bin/mkdir /bin/dirname ./
 
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
@@ -201,7 +201,7 @@ RUN sh -c 'i=0; while read DIR; do\
     done < /root/dir_abs.list'
 
 #  Remove write utils
-RUN rm ln rm mv
+RUN rm ln rm mv mkdir dirname
 
 # Install chain binaries
 COPY --from=build-env /root/bin /bin

--- a/dockerfile/cosmos/local.Dockerfile
+++ b/dockerfile/cosmos/local.Dockerfile
@@ -138,7 +138,7 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 WORKDIR /bin
 
 # Install ln (for making hard links) and rm (for cleanup) from full busybox image (will be deleted, only needed for image assembly)
-COPY --from=busybox-full /bin/ln /bin/mv /bin/rm ./
+COPY --from=busybox-full /bin/ln /bin/mv /bin/rm /bin/mkdir /bin/dirname ./
 
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
@@ -188,7 +188,7 @@ RUN sh -c 'i=0; while read DIR; do\
     done < /root/dir_abs.list'
 
 # Remove write utils
-RUN rm ln rm mv
+RUN rm ln rm mv mkdir dirname
 
 # Install trusted CA certificates
 COPY --from=alpine-3 /etc/ssl/cert.pem /etc/ssl/cert.pem

--- a/dockerfile/cosmos/localcross.Dockerfile
+++ b/dockerfile/cosmos/localcross.Dockerfile
@@ -146,7 +146,7 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 WORKDIR /bin
 
 # Install ln (for making hard links) and rm (for cleanup) from full busybox image (will be deleted, only needed for image assembly)
-COPY --from=busybox-full /bin/ln /bin/mv /bin/rm ./
+COPY --from=busybox-full /bin/ln /bin/mv /bin/rm /bin/mkdir /bin/dirname ./
 
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
@@ -196,7 +196,7 @@ RUN sh -c 'i=0; while read DIR; do\
     done < /root/dir_abs.list'
 
 #  Remove write utils
-RUN rm ln rm mv
+RUN rm ln rm mv mkdir dirname
 
 # Install chain binaries
 COPY --from=build-env /root/bin /bin

--- a/dockerfile/cosmos/native.Dockerfile
+++ b/dockerfile/cosmos/native.Dockerfile
@@ -124,7 +124,7 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 WORKDIR /bin
 
 # Install ln (for making hard links) and rm (for cleanup) from full busybox image (will be deleted, only needed for image assembly)
-COPY --from=busybox-full /bin/ln /bin/mv /bin/rm ./
+COPY --from=busybox-full /bin/ln /bin/mv /bin/rm /bin/mkdir /bin/dirname ./
 
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
@@ -174,7 +174,7 @@ RUN sh -c 'i=0; while read DIR; do\
     done < /root/dir_abs.list'
 
 #  Remove write utils
-RUN rm ln rm mv
+RUN rm ln rm mv mkdir dirname
 
 # Install chain binaries
 COPY --from=build-env /root/bin /bin


### PR DESCRIPTION
dir copy works if the dir path already exists in the final image, but not otherwise