### PR TITLE
fix: switcharoo on terra/terra-classic

### DIFF
--- a/chains/terra-classic.yaml
+++ b/chains/terra-classic.yaml
@@ -1,6 +1,6 @@
-# Terra
-- name: terra
-  github-organization: phoenix-directive
+# Terra Classic
+- name: terra-classic
+  github-organization: classic-terra
   github-repo: core
   dockerfile: cosmos
   build-target: make install
@@ -8,5 +8,3 @@
     - /go/bin/terrad
   build-env:
     - BUILD_TAGS=muslc
-
-


### PR DESCRIPTION
split didn't create terra file.
and terra now is run from phoenix-directive repo