### PR TITLE
chore: update golang version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/strangelove-ventures/heighliner
 
-go 1.21
+go 1.23
 
 require (
 	github.com/docker/cli v27.3.1+incompatible


### PR DESCRIPTION
Going to make modifications for future features.
Need golang 1.23 for those.