### PR TITLE
feat: add useful utilities to the chain docker images 

### DIFF
--- a/dockerfile/avalanche/Dockerfile
+++ b/dockerfile/avalanche/Dockerfile
@@ -117,8 +117,8 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install ln (for making hard links) and rm (for cleanup) from full busybox image (will be deleted, only needed for image assembly)
-COPY --from=busybox-full /bin/ln /bin/rm ./
+# Install ln (for making hard links), rm (for cleanup), mv, mkdir amd vi from full busybox image (will be deleted, only needed for image assembly)
+COPY --from=busybox-full /bin/ln /bin/rm /bin/mv /bin/mkdir /bin/vi ./
 
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
@@ -152,14 +152,10 @@ RUN for b in \
   tr \
   watch \
   which \
-  rm \
-  mv \
-  mkdir \
-  vi \
   ; do ln sh $b; done
 
 #  Remove write utils
-RUN rm ln rm
+RUN rm ln
 
 # Install chain binaries
 COPY --from=build-env /root/bin /bin

--- a/dockerfile/avalanche/Dockerfile
+++ b/dockerfile/avalanche/Dockerfile
@@ -40,7 +40,7 @@ RUN set -eux;\
         LIBDIR=/usr/aarch64-linux-musl/lib;\
         mkdir -p $LIBDIR;\
         export CC=aarch64-linux-musl-gcc CXX=aarch64-linux-musl-g++;\
-      fi;\  
+      fi;\
     elif [ "${TARGETARCH}" = "amd64" ]; then\
       export ARCH=x86_64;\
       if [ "${BUILDARCH}" != "amd64" ]; then\
@@ -152,6 +152,10 @@ RUN for b in \
   tr \
   watch \
   which \
+  rm \
+  mv \
+  mkdir \
+  vi \
   ; do ln sh $b; done
 
 #  Remove write utils

--- a/dockerfile/avalanche/native.Dockerfile
+++ b/dockerfile/avalanche/native.Dockerfile
@@ -129,6 +129,10 @@ RUN for b in \
   tr \
   watch \
   which \
+  rm \
+  mv \
+  mkdir \
+  vi \
   ; do ln sh $b; done
 
 #  Remove write utils

--- a/dockerfile/avalanche/native.Dockerfile
+++ b/dockerfile/avalanche/native.Dockerfile
@@ -94,8 +94,8 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install ln (for making hard links) and rm (for cleanup) from full busybox image (will be deleted, only needed for image assembly)
-COPY --from=busybox-full /bin/ln /bin/rm ./
+# Install ln (for making hard links), rm (for cleanup), mv, mkdir, amd vi from full busybox image (will be deleted, only needed for image assembly)
+COPY --from=busybox-full /bin/ln /bin/rm /bin/mv /bin/mkdir /bin/vi ./
 
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
@@ -129,14 +129,10 @@ RUN for b in \
   tr \
   watch \
   which \
-  rm \
-  mv \
-  mkdir \
-  vi \
   ; do ln sh $b; done
 
 #  Remove write utils
-RUN rm ln rm
+RUN rm ln
 
 # Install chain binaries
 COPY --from=build-env /root/bin /bin

--- a/dockerfile/cargo/Dockerfile
+++ b/dockerfile/cargo/Dockerfile
@@ -226,8 +226,8 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install ln (for making hard links), rm (for cleanup), mv, mkdir, and dirname from full busybox image (will be deleted, only needed for image assembly)
-COPY --from=busybox-full /bin/ln /bin/rm /bin/mv /bin/mkdir /bin/dirname ./
+# Install ln (for making hard links), rm (for cleanup), mv, mkdir, vi and dirname from full busybox image (will be deleted, only needed for image assembly)
+COPY --from=busybox-full /bin/ln /bin/rm /bin/mv /bin/mkdir /bin/vi /bin/dirname ./
 
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
@@ -261,10 +261,6 @@ RUN for b in \
   tr \
   watch \
   which \
-  rm \
-  mv \
-  mkdir \
-  vi \
   ; do ln sh $b; done
 
 # Install chain binaries
@@ -305,7 +301,7 @@ ARG FINAL_IMAGE
 RUN if [ ! -z "$FINAL_IMAGE" ]; then sh -c "$FINAL_IMAGE"; fi
 
 # Remove write utils used to construct image and tmp dir/file for lib copy.
-RUN rm -rf ln rm mv mkdir dirname /root/lib_abs /root/lib_abs.list
+RUN rm -rf ln dirname /root/lib_abs /root/lib_abs.list
 
 # Install trusted CA certificates
 COPY --from=alpine-3 /etc/ssl/cert.pem /etc/ssl/cert.pem

--- a/dockerfile/cargo/Dockerfile
+++ b/dockerfile/cargo/Dockerfile
@@ -261,6 +261,10 @@ RUN for b in \
   tr \
   watch \
   which \
+  rm \
+  mv \
+  mkdir \
+  vi \
   ; do ln sh $b; done
 
 # Install chain binaries

--- a/dockerfile/cargo/native.Dockerfile
+++ b/dockerfile/cargo/native.Dockerfile
@@ -211,6 +211,10 @@ RUN for b in \
   tr \
   watch \
   which \
+  rm \
+  mv \
+  mkdir \
+  vi \
   ; do ln sh $b; done
 
 # Install chain binaries

--- a/dockerfile/cargo/native.Dockerfile
+++ b/dockerfile/cargo/native.Dockerfile
@@ -176,8 +176,8 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install ln (for making hard links), rm (for cleanup), mv, mkdir, and dirname from full busybox image (will be deleted, only needed for image assembly)
-COPY --from=busybox-full /bin/ln /bin/rm /bin/mv /bin/mkdir /bin/dirname ./
+# Install ln (for making hard links), rm (for cleanup), mv, mkdir, vi and dirname from full busybox image (will be deleted, only needed for image assembly)
+COPY --from=busybox-full /bin/ln /bin/rm /bin/mv /bin/mkdir /bin/vi /bin/dirname ./
 
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
@@ -211,10 +211,6 @@ RUN for b in \
   tr \
   watch \
   which \
-  rm \
-  mv \
-  mkdir \
-  vi \
   ; do ln sh $b; done
 
 # Install chain binaries
@@ -255,7 +251,7 @@ ARG FINAL_IMAGE
 RUN if [ ! -z "$FINAL_IMAGE" ]; then sh -c "$FINAL_IMAGE"; fi
 
 # Remove write utils used to construct image and tmp dir/file for lib copy.
-RUN rm -rf ln rm mv mkdir dirname /root/lib_abs /root/lib_abs.list
+RUN rm -rf ln dirname /root/lib_abs /root/lib_abs.list
 
 # Install trusted CA certificates
 COPY --from=alpine-3 /etc/ssl/cert.pem /etc/ssl/cert.pem

--- a/dockerfile/cosmos/Dockerfile
+++ b/dockerfile/cosmos/Dockerfile
@@ -185,6 +185,10 @@ RUN for b in \
   tr \
   watch \
   which \
+  rm \
+  mv \
+  mkdir \
+  vi \
   ; do ln sh $b; done
 
 # Copy over absolute path directories

--- a/dockerfile/cosmos/Dockerfile
+++ b/dockerfile/cosmos/Dockerfile
@@ -150,8 +150,8 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install ln (for making hard links) and rm (for cleanup) from full busybox image (will be deleted, only needed for image assembly)
-COPY --from=busybox-full /bin/ln /bin/mv /bin/rm /bin/mkdir /bin/dirname ./
+# Install ln (for making hard links), rm (for cleanup), mv, mkdir, vi and dirname from full busybox image (will be deleted, only needed for image assembly)
+COPY --from=busybox-full /bin/ln /bin/mv /bin/rm /bin/mkdir /bin/vi /bin/dirname ./
 
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
@@ -185,10 +185,6 @@ RUN for b in \
   tr \
   watch \
   which \
-  rm \
-  mv \
-  mkdir \
-  vi \
   ; do ln sh $b; done
 
 # Copy over absolute path directories
@@ -205,7 +201,7 @@ RUN sh -c 'i=0; while read DIR; do\
     done < /root/dir_abs.list'
 
 #  Remove write utils
-RUN rm ln rm mv mkdir dirname
+RUN rm ln dirname
 
 # Install chain binaries
 COPY --from=build-env /root/bin /bin

--- a/dockerfile/cosmos/local.Dockerfile
+++ b/dockerfile/cosmos/local.Dockerfile
@@ -176,6 +176,10 @@ RUN for b in \
   tr \
   watch \
   which \
+  rm \
+  mv \
+  mkdir \
+  vi \
   ; do ln sh $b; done
 
 # Copy over absolute path directories

--- a/dockerfile/cosmos/local.Dockerfile
+++ b/dockerfile/cosmos/local.Dockerfile
@@ -141,8 +141,8 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install ln (for making hard links) and rm (for cleanup) from full busybox image (will be deleted, only needed for image assembly)
-COPY --from=busybox-full /bin/ln /bin/mv /bin/rm /bin/mkdir /bin/dirname ./
+# Install ln (for making hard links), rm (for cleanup), mv, mkdir, vi and dirname from full busybox image (will be deleted, only needed for image assembly)
+COPY --from=busybox-full /bin/ln /bin/mv /bin/rm /bin/mkdir /bin/vi /bin/dirname ./
 
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
@@ -176,10 +176,6 @@ RUN for b in \
   tr \
   watch \
   which \
-  rm \
-  mv \
-  mkdir \
-  vi \
   ; do ln sh $b; done
 
 # Copy over absolute path directories
@@ -196,7 +192,7 @@ RUN sh -c 'i=0; while read DIR; do\
     done < /root/dir_abs.list'
 
 # Remove write utils
-RUN rm ln rm mv mkdir dirname
+RUN rm ln dirname
 
 # Install trusted CA certificates
 COPY --from=alpine-3 /etc/ssl/cert.pem /etc/ssl/cert.pem

--- a/dockerfile/cosmos/localcross.Dockerfile
+++ b/dockerfile/cosmos/localcross.Dockerfile
@@ -145,8 +145,8 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install ln (for making hard links) and rm (for cleanup) from full busybox image (will be deleted, only needed for image assembly)
-COPY --from=busybox-full /bin/ln /bin/mv /bin/rm /bin/mkdir /bin/dirname ./
+# Install ln (for making hard links), rm (for cleanup), mv, mkdir, vi and dirname from full busybox image (will be deleted, only needed for image assembly)
+COPY --from=busybox-full /bin/ln /bin/mv /bin/rm /bin/mkdir /bin/vi /bin/dirname ./
 
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
@@ -180,10 +180,6 @@ RUN for b in \
   tr \
   watch \
   which \
-  rm \
-  mv \
-  mkdir \
-  vi \
   ; do ln sh $b; done
 
 # Copy over absolute path directories
@@ -200,7 +196,7 @@ RUN sh -c 'i=0; while read DIR; do\
     done < /root/dir_abs.list'
 
 #  Remove write utils
-RUN rm ln rm mv mkdir dirname
+RUN rm ln dirname
 
 # Install chain binaries
 COPY --from=build-env /root/bin /bin

--- a/dockerfile/cosmos/localcross.Dockerfile
+++ b/dockerfile/cosmos/localcross.Dockerfile
@@ -180,6 +180,10 @@ RUN for b in \
   tr \
   watch \
   which \
+  rm \
+  mv \
+  mkdir \
+  vi \
   ; do ln sh $b; done
 
 # Copy over absolute path directories

--- a/dockerfile/cosmos/native.Dockerfile
+++ b/dockerfile/cosmos/native.Dockerfile
@@ -158,6 +158,10 @@ RUN for b in \
   tr \
   watch \
   which \
+  rm \
+  mv \
+  mkdir \
+  vi \
   ; do ln sh $b; done
 
 # Copy over absolute path directories

--- a/dockerfile/cosmos/native.Dockerfile
+++ b/dockerfile/cosmos/native.Dockerfile
@@ -123,8 +123,8 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install ln (for making hard links) and rm (for cleanup) from full busybox image (will be deleted, only needed for image assembly)
-COPY --from=busybox-full /bin/ln /bin/mv /bin/rm /bin/mkdir /bin/dirname ./
+# Install ln (for making hard links), rm (for cleanup), mv, mkdir, vi and dirname from full busybox image (will be deleted, only needed for image assembly)
+COPY --from=busybox-full /bin/ln /bin/mv /bin/rm /bin/mkdir /bin/vi /bin/dirname ./
 
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
@@ -158,10 +158,6 @@ RUN for b in \
   tr \
   watch \
   which \
-  rm \
-  mv \
-  mkdir \
-  vi \
   ; do ln sh $b; done
 
 # Copy over absolute path directories
@@ -178,7 +174,7 @@ RUN sh -c 'i=0; while read DIR; do\
     done < /root/dir_abs.list'
 
 #  Remove write utils
-RUN rm ln rm mv mkdir dirname
+RUN rm dirname
 
 # Install chain binaries
 COPY --from=build-env /root/bin /bin

--- a/dockerfile/imported/Dockerfile
+++ b/dockerfile/imported/Dockerfile
@@ -162,6 +162,10 @@ RUN for b in \
   tr \
   watch \
   which \
+  rm \
+  mv \
+  mkdir \
+  vi \
   ; do ln sh $b; done
 
 # Install chain binaries

--- a/dockerfile/imported/Dockerfile
+++ b/dockerfile/imported/Dockerfile
@@ -127,8 +127,8 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install ln (for making hard links), rm (for cleanup), mv, mkdir, and dirname from full busybox image (will be deleted, only needed for image assembly)
-COPY --from=busybox-full /bin/ln /bin/rm /bin/mv /bin/mkdir /bin/dirname ./
+# Install ln (for making hard links), rm (for cleanup), mv, mkdir, vi and dirname from full busybox image (will be deleted, only needed for image assembly)
+COPY --from=busybox-full /bin/ln /bin/mv /bin/rm /bin/mkdir /bin/vi /bin/dirname ./
 
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
@@ -162,10 +162,6 @@ RUN for b in \
   tr \
   watch \
   which \
-  rm \
-  mv \
-  mkdir \
-  vi \
   ; do ln sh $b; done
 
 # Install chain binaries
@@ -206,7 +202,7 @@ ARG FINAL_IMAGE
 RUN if [ ! -z "$FINAL_IMAGE" ]; then sh -c "$FINAL_IMAGE"; fi
 
 # Remove write utils used to construct image and tmp dir/file for lib copy.
-RUN rm -rf ln rm mv mkdir dirname /root/lib_abs /root/lib_abs.list
+RUN rm -rf ln dirname /root/lib_abs /root/lib_abs.list
 
 # Install trusted CA certificates
 COPY --from=alpine-3 /etc/ssl/cert.pem /etc/ssl/cert.pem


### PR DESCRIPTION
This PR is for adding useful utilities to the chain docker images ( mkdir, vi, rm and mv)

**_Ref_**: [301](https://github.com/strangelove-ventures/heighliner/issues/301)

## Changes: 
- Install / Enable necessary applet 
  - rm (for cleanup)
  - mv (for moving / renaming files)
  - mkdir (for creating directories)
  - vi  (for editing files')
- Prevent those write utils from being removed

## Tests: 
- While preparing the test, I grouped the chains into 4 categories : 
  - avalanche
  - cargo
  - cosmos
  - imported
- And for each of those categories , I had to run a test.
  - **_avalanche_**
    - **Chain:** avalanche
    - **Image:** ghcr.io/strangelove-ventures/heighliner/avalanche:v1.11.11-utility 
<img width="1062" alt="image" src="https://github.com/user-attachments/assets/31c935ed-7f51-4971-bd23-3f3aa09f5a66" />
  
  - **_cargo_**
    - **Chain:** neutron
    - **Image:** ghcr.io/strangelove-ventures/heighliner/neutron:v5.0.5-utility
<img width="1008" alt="image" src="https://github.com/user-attachments/assets/2deec834-1dad-455b-b620-00f548517d96" />
  
  - **_cosmos_**
    - **Chain:** sei
	
  - **_Imported_**
    - **Chain:** union
    - **Image:** ghcr.io/strangelove-ventures/heighliner/union:v0.24.0-utility
<img width="1008" alt="image" src="https://github.com/user-attachments/assets/2608bd63-342f-44c5-b5a5-6955bef31632" />


Author Checklist

- [x] Updated PR status in SL Platform Project
 