### PR TITLE
fix: add go mod tidy command to solve the bump test failure

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.23'
+
+      - name: Install dependencies
+        run: go mod tidy
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:


### PR DESCRIPTION
## Description
This PR to fix a test issue encountered in a bump PR https://github.com/strangelove-ventures/heighliner/pull/316

## Changes
- Add go mod tidy to the pipeline as the errors stated
`level=error msg="Running error: context loading failed: no go files to analyze: running `go mod tidy` may solve the problem"
27`
## Tests
- Will run the bump PR to see if this is fixed
## Author checklist
- N/A