### PR TITLE
fix: remove busybox-full bins from the final image

### DIFF
--- a/dockerfile/avalanche/Dockerfile
+++ b/dockerfile/avalanche/Dockerfile
@@ -130,7 +130,6 @@ RUN for b in \
   env \
   grep \
   head \
-  jq \
   less \
   ls \
   md5sum \

--- a/dockerfile/avalanche/Dockerfile
+++ b/dockerfile/avalanche/Dockerfile
@@ -101,7 +101,7 @@ RUN bash -c 'set -eux;\
   LIBRARIES_ARR=($LIBRARIES_ENV); for LIBRARY in "${LIBRARIES_ARR[@]}"; do cp $LIBRARY /root/lib/; done'
 
 # Use minimal busybox from infra-toolkit image for final scratch image
-FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.10 AS infra-toolkit
+FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.12 AS infra-toolkit
 RUN addgroup --gid 1025 -S heighliner && adduser --uid 1025 -S heighliner -G heighliner
 
 # Use alpine to source the latest CA certificates
@@ -114,8 +114,10 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install minimal busybox as ln binary (will create hardlinks for the rest of the binaries to this data)
+# Installa minimal busybox as `sh` and `ln` binaries
+# sh allows using `RUN` commands
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
+# ln creates hardlinks for exposed binaries from infra-toolkit min config
 COPY --from=infra-toolkit /busybox/busybox /bin/ln
 
 # Install jq
@@ -139,6 +141,7 @@ RUN for b in \
   mv \
   pwd \
   rm \
+  sed \
   sha1sum \
   sha256sum \
   sha3sum \

--- a/dockerfile/avalanche/Dockerfile
+++ b/dockerfile/avalanche/Dockerfile
@@ -117,22 +117,6 @@ WORKDIR /bin
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 
-# Install jq
-COPY --from=infra-toolkit /usr/local/bin/jq /bin/
-
-# Install rm
-COPY --from=infra-toolkit /busybox/bin/rm /bin/rm
-
-# Install mv
-COPY --from=infra-toolkit /busybox/bin/mv /bin/mv
-
-# Install ln
-COPY --from=infra-toolkit /busybox/bin/ln /bin/ln
-
-# Install vi
-COPY --from=infra-toolkit /busybox/bin/vi /bin/vi
-
-
 # Add hard links for utils
 # Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode
 RUN for b in \

--- a/dockerfile/avalanche/Dockerfile
+++ b/dockerfile/avalanche/Dockerfile
@@ -114,7 +114,7 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install a minimal busybox as `sh` and `ln` binaries
+# Install minimal busybox as `sh` and `ln` binaries
 # sh allows using `RUN` commands
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 # ln creates hardlinks for exposed binaries from infra-toolkit min config

--- a/dockerfile/avalanche/Dockerfile
+++ b/dockerfile/avalanche/Dockerfile
@@ -133,7 +133,7 @@ COPY --from=infra-toolkit /busybox/bin/ln /bin/ln
 COPY --from=infra-toolkit /busybox/bin/vi /bin/vi
 
 
-# Add hard links for read-only utils
+# Add hard links for utils
 # Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode
 RUN for b in \
   cat \
@@ -143,10 +143,13 @@ RUN for b in \
   env \
   grep \
   head \
+  jq \
   less \
   ls \
   md5sum \
+  mv \
   pwd \
+  rm \
   sha1sum \
   sha256sum \
   sha3sum \
@@ -157,12 +160,10 @@ RUN for b in \
   tar \
   tee \
   tr \
+  vi \
   watch \
   which \
   ; do ln sh $b; done
-
-#  Remove write utils
-RUN rm ln
 
 # Install chain binaries
 COPY --from=build-env /root/bin /bin

--- a/dockerfile/avalanche/Dockerfile
+++ b/dockerfile/avalanche/Dockerfile
@@ -114,8 +114,9 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install ln
-COPY --from=infra-toolkit /bin/ln /bin/
+# Install minimal busybox as ln binary (will create hardlinks for the rest of the binaries to this data)
+COPY --from=infra-toolkit /busybox/busybox /bin/sh
+COPY --from=infra-toolkit /busybox/busybox /bin/ln
 
 # Install jq
 COPY --from=infra-toolkit /usr/local/bin/jq /bin/
@@ -126,6 +127,7 @@ RUN for b in \
   cat \
   date \
   df \
+  dirname \
   du \
   env \
   grep \
@@ -133,6 +135,7 @@ RUN for b in \
   less \
   ls \
   md5sum \
+  mkdir \
   mv \
   pwd \
   rm \
@@ -149,8 +152,9 @@ RUN for b in \
   vi \
   watch \
   which \
-  sh \
-  ; do ln ln $b; done
+  ; do ln ln $b; done; \
+  rm -rf sh; \
+  ln ln sh;
 
 # Install chain binaries
 COPY --from=build-env /root/bin /bin

--- a/dockerfile/avalanche/Dockerfile
+++ b/dockerfile/avalanche/Dockerfile
@@ -114,9 +114,6 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
-COPY --from=infra-toolkit /busybox/busybox /bin/sh
-
 COPY --from=infra-toolkit /busybox/busybox /bin/ln
 
 # Install jq

--- a/dockerfile/avalanche/Dockerfile
+++ b/dockerfile/avalanche/Dockerfile
@@ -101,7 +101,7 @@ RUN bash -c 'set -eux;\
   LIBRARIES_ARR=($LIBRARIES_ENV); for LIBRARY in "${LIBRARIES_ARR[@]}"; do cp $LIBRARY /root/lib/; done'
 
 # Use minimal busybox from infra-toolkit image for final scratch image
-FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.4 AS infra-toolkit
+FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.10 AS infra-toolkit
 RUN addgroup --gid 1025 -S heighliner && adduser --uid 1025 -S heighliner -G heighliner
 
 # Use alpine to source the latest CA certificates
@@ -114,7 +114,8 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-COPY --from=infra-toolkit /busybox/busybox /bin/ln
+# Install ln
+COPY --from=infra-toolkit /bin/ln /bin/
 
 # Install jq
 COPY --from=infra-toolkit /usr/local/bin/jq /bin/

--- a/dockerfile/avalanche/Dockerfile
+++ b/dockerfile/avalanche/Dockerfile
@@ -104,9 +104,6 @@ RUN bash -c 'set -eux;\
 FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.4 AS infra-toolkit
 RUN addgroup --gid 1025 -S heighliner && adduser --uid 1025 -S heighliner -G heighliner
 
-# Use ln and rm from full featured busybox for assembling final image
-FROM busybox:1.34.1-musl AS busybox-full
-
 # Use alpine to source the latest CA certificates
 FROM alpine:3 as alpine-3
 
@@ -117,14 +114,24 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install ln (for making hard links), rm (for cleanup), mv, mkdir amd vi from full busybox image (will be deleted, only needed for image assembly)
-COPY --from=busybox-full /bin/ln /bin/rm /bin/mv /bin/mkdir /bin/vi ./
-
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 
 # Install jq
 COPY --from=infra-toolkit /usr/local/bin/jq /bin/
+
+# Install rm
+COPY --from=infra-toolkit /busybox/bin/rm /bin/rm
+
+# Install mv
+COPY --from=infra-toolkit /busybox/bin/mv /bin/mv
+
+# Install ln
+COPY --from=infra-toolkit /busybox/bin/ln /bin/ln
+
+# Install vi
+COPY --from=infra-toolkit /busybox/bin/vi /bin/vi
+
 
 # Add hard links for read-only utils
 # Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode

--- a/dockerfile/avalanche/Dockerfile
+++ b/dockerfile/avalanche/Dockerfile
@@ -117,6 +117,11 @@ WORKDIR /bin
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 
+COPY --from=infra-toolkit /busybox/busybox /bin/ln
+
+# Install jq
+COPY --from=infra-toolkit /usr/local/bin/jq /bin/
+
 # Add hard links for utils
 # Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode
 RUN for b in \
@@ -147,7 +152,8 @@ RUN for b in \
   vi \
   watch \
   which \
-  ; do ln sh $b; done
+  sh \
+  ; do ln ln $b; done
 
 # Install chain binaries
 COPY --from=build-env /root/bin /bin

--- a/dockerfile/avalanche/Dockerfile
+++ b/dockerfile/avalanche/Dockerfile
@@ -114,7 +114,7 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Installa minimal busybox as `sh` and `ln` binaries
+# Install a minimal busybox as `sh` and `ln` binaries
 # sh allows using `RUN` commands
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 # ln creates hardlinks for exposed binaries from infra-toolkit min config

--- a/dockerfile/avalanche/native.Dockerfile
+++ b/dockerfile/avalanche/native.Dockerfile
@@ -125,7 +125,7 @@ RUN for b in \
   vi \
   watch \
   which \
-; do ln sh $b; done
+  ; do ln sh $b; done
 
 # Install chain binaries
 COPY --from=build-env /root/bin /bin

--- a/dockerfile/avalanche/native.Dockerfile
+++ b/dockerfile/avalanche/native.Dockerfile
@@ -91,9 +91,6 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
-COPY --from=infra-toolkit /busybox/busybox /bin/sh
-
 COPY --from=infra-toolkit /busybox/busybox /bin/ln
 
 # Install jq

--- a/dockerfile/avalanche/native.Dockerfile
+++ b/dockerfile/avalanche/native.Dockerfile
@@ -91,7 +91,7 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Installa minimal busybox as `sh` and `ln` binaries
+# Install a minimal busybox as `sh` and `ln` binaries
 # sh allows using `RUN` commands
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 # ln creates hardlinks for exposed binaries from infra-toolkit min config

--- a/dockerfile/avalanche/native.Dockerfile
+++ b/dockerfile/avalanche/native.Dockerfile
@@ -91,8 +91,9 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install ln
-COPY --from=infra-toolkit /bin/ln /bin/
+# Install minimal busybox as ln binary (will create hardlinks for the rest of the binaries to this data)
+COPY --from=infra-toolkit /busybox/busybox /bin/sh
+COPY --from=infra-toolkit /busybox/busybox /bin/ln
 
 # Install jq
 COPY --from=infra-toolkit /usr/local/bin/jq /bin/
@@ -103,6 +104,7 @@ RUN for b in \
   cat \
   date \
   df \
+  dirname \
   du \
   env \
   grep \
@@ -110,6 +112,7 @@ RUN for b in \
   less \
   ls \
   md5sum \
+  mkdir \
   mv \
   pwd \
   rm \
@@ -126,8 +129,9 @@ RUN for b in \
   vi \
   watch \
   which \
-  sh \
-  ; do ln ln $b; done
+  ; do ln ln $b; done; \
+  rm -rf sh; \
+  ln ln sh;
 
 # Install chain binaries
 COPY --from=build-env /root/bin /bin

--- a/dockerfile/avalanche/native.Dockerfile
+++ b/dockerfile/avalanche/native.Dockerfile
@@ -107,7 +107,6 @@ RUN for b in \
   env \
   grep \
   head \
-  jq \
   less \
   ls \
   md5sum \

--- a/dockerfile/avalanche/native.Dockerfile
+++ b/dockerfile/avalanche/native.Dockerfile
@@ -94,6 +94,10 @@ WORKDIR /bin
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 
+COPY --from=infra-toolkit /busybox/busybox /bin/ln
+
+# Install jq
+COPY --from=infra-toolkit /usr/local/bin/jq /bin/
 
 # Add hard links for utils
 # Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode
@@ -125,7 +129,8 @@ RUN for b in \
   vi \
   watch \
   which \
-  ; do ln sh $b; done
+  sh \
+  ; do ln ln $b; done
 
 # Install chain binaries
 COPY --from=build-env /root/bin /bin

--- a/dockerfile/avalanche/native.Dockerfile
+++ b/dockerfile/avalanche/native.Dockerfile
@@ -78,7 +78,7 @@ RUN bash -c 'set -eux;\
   LIBRARIES_ARR=($LIBRARIES_ENV); for LIBRARY in "${LIBRARIES_ARR[@]}"; do cp $LIBRARY /root/lib/; done'
 
 # Use minimal busybox from infra-toolkit image for final scratch image
-FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.10 AS infra-toolkit
+FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.12 AS infra-toolkit
 RUN addgroup --gid 1025 -S heighliner && adduser --uid 1025 -S heighliner -G heighliner
 
 # Use alpine to source the latest CA certificates
@@ -91,8 +91,10 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install minimal busybox as ln binary (will create hardlinks for the rest of the binaries to this data)
+# Installa minimal busybox as `sh` and `ln` binaries
+# sh allows using `RUN` commands
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
+# ln creates hardlinks for exposed binaries from infra-toolkit min config
 COPY --from=infra-toolkit /busybox/busybox /bin/ln
 
 # Install jq
@@ -116,6 +118,7 @@ RUN for b in \
   mv \
   pwd \
   rm \
+  sed \
   sha1sum \
   sha256sum \
   sha3sum \

--- a/dockerfile/avalanche/native.Dockerfile
+++ b/dockerfile/avalanche/native.Dockerfile
@@ -94,22 +94,8 @@ WORKDIR /bin
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 
-# Install jq
-COPY --from=infra-toolkit /usr/local/bin/jq /bin/
 
-# Install rm
-COPY --from=infra-toolkit /busybox/bin/rm /bin/rm
-
-# Install mv
-COPY --from=infra-toolkit /busybox/bin/mv /bin/mv
-
-# Install ln
-COPY --from=infra-toolkit /busybox/bin/ln /bin/ln
-
-# Install vi
-COPY --from=infra-toolkit /busybox/bin/vi /bin/vi
-
-# Add hard links for read-only utils
+# Add hard links for utils
 # Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode
 RUN for b in \
   cat \
@@ -119,10 +105,13 @@ RUN for b in \
   env \
   grep \
   head \
+  jq \
   less \
   ls \
   md5sum \
+  mv \
   pwd \
+  rm \
   sha1sum \
   sha256sum \
   sha3sum \
@@ -133,12 +122,10 @@ RUN for b in \
   tar \
   tee \
   tr \
+  vi \
   watch \
   which \
-  ; do ln sh $b; done
-
-#  Remove write utils
-RUN rm ln
+; do ln sh $b; done
 
 # Install chain binaries
 COPY --from=build-env /root/bin /bin

--- a/dockerfile/avalanche/native.Dockerfile
+++ b/dockerfile/avalanche/native.Dockerfile
@@ -91,7 +91,7 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install a minimal busybox as `sh` and `ln` binaries
+# Install minimal busybox as `sh` and `ln` binaries
 # sh allows using `RUN` commands
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 # ln creates hardlinks for exposed binaries from infra-toolkit min config

--- a/dockerfile/avalanche/native.Dockerfile
+++ b/dockerfile/avalanche/native.Dockerfile
@@ -78,7 +78,7 @@ RUN bash -c 'set -eux;\
   LIBRARIES_ARR=($LIBRARIES_ENV); for LIBRARY in "${LIBRARIES_ARR[@]}"; do cp $LIBRARY /root/lib/; done'
 
 # Use minimal busybox from infra-toolkit image for final scratch image
-FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.4 AS infra-toolkit
+FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.10 AS infra-toolkit
 RUN addgroup --gid 1025 -S heighliner && adduser --uid 1025 -S heighliner -G heighliner
 
 # Use alpine to source the latest CA certificates
@@ -91,7 +91,8 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-COPY --from=infra-toolkit /busybox/busybox /bin/ln
+# Install ln
+COPY --from=infra-toolkit /bin/ln /bin/
 
 # Install jq
 COPY --from=infra-toolkit /usr/local/bin/jq /bin/

--- a/dockerfile/cargo/Dockerfile
+++ b/dockerfile/cargo/Dockerfile
@@ -226,6 +226,11 @@ WORKDIR /bin
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 
+COPY --from=infra-toolkit /busybox/busybox /bin/ln
+
+# Install jq
+COPY --from=infra-toolkit /usr/local/bin/jq /bin/
+
 # Add hard links for utils
 # Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode
 RUN for b in \
@@ -256,7 +261,8 @@ RUN for b in \
   vi \
   watch \
   which \
-; do ln sh $b; done
+  sh \
+  ; do ln ln $b; done
 
 # Install chain binaries
 COPY --from=build-env /root/bin /bin

--- a/dockerfile/cargo/Dockerfile
+++ b/dockerfile/cargo/Dockerfile
@@ -146,7 +146,7 @@ RUN bash -c 'set -eux;\
   done'
 
 # Use minimal busybox from infra-toolkit image for final scratch image
-FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.4 AS infra-toolkit
+FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.10 AS infra-toolkit
 RUN addgroup --gid 1025 -S heighliner && adduser --uid 1025 -S heighliner -G heighliner
 
 # Use alpine to source the latest CA certificates
@@ -224,9 +224,10 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 WORKDIR /bin
 
 # Install dirname
-COPY --from=infra-toolkit /busybox/dirname /bin/dirname
+COPY --from=infra-toolkit /usr/bin/dirname /bin/
 
-COPY --from=infra-toolkit /busybox/busybox /bin/ln
+# Install ln
+COPY --from=infra-toolkit /bin/ln /bin/
 
 # Install jq
 COPY --from=infra-toolkit /usr/local/bin/jq /bin/

--- a/dockerfile/cargo/Dockerfile
+++ b/dockerfile/cargo/Dockerfile
@@ -223,7 +223,7 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install a minimal busybox as `sh` and `ln` binaries
+# Install minimal busybox as `sh` and `ln` binaries
 # sh allows using `RUN` commands
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 # ln creates hardlinks for exposed binaries from infra-toolkit min config

--- a/dockerfile/cargo/Dockerfile
+++ b/dockerfile/cargo/Dockerfile
@@ -149,9 +149,6 @@ RUN bash -c 'set -eux;\
 FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.4 AS infra-toolkit
 RUN addgroup --gid 1025 -S heighliner && adduser --uid 1025 -S heighliner -G heighliner
 
-# Use ln and rm from full featured busybox for assembling final image
-FROM busybox:1.34.1-musl AS busybox-full
-
 # Use alpine to source the latest CA certificates
 FROM alpine:3 as alpine-3
 
@@ -226,14 +223,23 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install ln (for making hard links), rm (for cleanup), mv, mkdir, vi and dirname from full busybox image (will be deleted, only needed for image assembly)
-COPY --from=busybox-full /bin/ln /bin/rm /bin/mv /bin/mkdir /bin/vi /bin/dirname ./
-
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 
 # Install jq
 COPY --from=infra-toolkit /usr/local/bin/jq /bin/
+
+# Install rm
+COPY --from=infra-toolkit /busybox/bin/rm /bin/rm
+
+# Install mv
+COPY --from=infra-toolkit /busybox/bin/mv /bin/mv
+
+# Install ln
+COPY --from=infra-toolkit /busybox/bin/ln /bin/ln
+
+# Install vi
+COPY --from=infra-toolkit /busybox/bin/vi /bin/vi
 
 # Add hard links for read-only utils
 # Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode

--- a/dockerfile/cargo/Dockerfile
+++ b/dockerfile/cargo/Dockerfile
@@ -226,9 +226,6 @@ WORKDIR /bin
 # Install dirname
 COPY --from=infra-toolkit /busybox/dirname /bin/dirname
 
-# Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
-COPY --from=infra-toolkit /busybox/busybox /bin/sh
-
 COPY --from=infra-toolkit /busybox/busybox /bin/ln
 
 # Install jq

--- a/dockerfile/cargo/Dockerfile
+++ b/dockerfile/cargo/Dockerfile
@@ -146,7 +146,7 @@ RUN bash -c 'set -eux;\
   done'
 
 # Use minimal busybox from infra-toolkit image for final scratch image
-FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.10 AS infra-toolkit
+FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.12 AS infra-toolkit
 RUN addgroup --gid 1025 -S heighliner && adduser --uid 1025 -S heighliner -G heighliner
 
 # Use alpine to source the latest CA certificates
@@ -223,8 +223,10 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install minimal busybox as ln binary (will create hardlinks for the rest of the binaries to this data)
+# Installa minimal busybox as `sh` and `ln` binaries
+# sh allows using `RUN` commands
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
+# ln creates hardlinks for exposed binaries from infra-toolkit min config
 COPY --from=infra-toolkit /busybox/busybox /bin/ln
 
 # Install jq
@@ -248,6 +250,7 @@ RUN for b in \
   mv \
   pwd \
   rm \
+  sed \
   sha1sum \
   sha256sum \
   sha3sum \

--- a/dockerfile/cargo/Dockerfile
+++ b/dockerfile/cargo/Dockerfile
@@ -243,7 +243,6 @@ RUN for b in \
   env \
   grep \
   head \
-  jq \
   less \
   ls \
   md5sum \

--- a/dockerfile/cargo/Dockerfile
+++ b/dockerfile/cargo/Dockerfile
@@ -223,6 +223,9 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
+# Install dirname
+COPY --from=infra-toolkit /busybox/dirname /bin/dirname
+
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 
@@ -237,6 +240,7 @@ RUN for b in \
   cat \
   date \
   df \
+  dirname \
   du \
   env \
   grep \

--- a/dockerfile/cargo/Dockerfile
+++ b/dockerfile/cargo/Dockerfile
@@ -223,11 +223,9 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install dirname
-COPY --from=infra-toolkit /usr/bin/dirname /bin/
-
-# Install ln
-COPY --from=infra-toolkit /bin/ln /bin/
+# Install minimal busybox as ln binary (will create hardlinks for the rest of the binaries to this data)
+COPY --from=infra-toolkit /busybox/busybox /bin/sh
+COPY --from=infra-toolkit /busybox/busybox /bin/ln
 
 # Install jq
 COPY --from=infra-toolkit /usr/local/bin/jq /bin/
@@ -246,6 +244,7 @@ RUN for b in \
   less \
   ls \
   md5sum \
+  mkdir \
   mv \
   pwd \
   rm \
@@ -262,8 +261,9 @@ RUN for b in \
   vi \
   watch \
   which \
-  sh \
-  ; do ln ln $b; done
+  ; do ln ln $b; done; \
+  rm -rf sh; \
+  ln ln sh;
 
 # Install chain binaries
 COPY --from=build-env /root/bin /bin

--- a/dockerfile/cargo/Dockerfile
+++ b/dockerfile/cargo/Dockerfile
@@ -223,7 +223,7 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Installa minimal busybox as `sh` and `ln` binaries
+# Install a minimal busybox as `sh` and `ln` binaries
 # sh allows using `RUN` commands
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 # ln creates hardlinks for exposed binaries from infra-toolkit min config

--- a/dockerfile/cargo/Dockerfile
+++ b/dockerfile/cargo/Dockerfile
@@ -226,22 +226,7 @@ WORKDIR /bin
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 
-# Install jq
-COPY --from=infra-toolkit /usr/local/bin/jq /bin/
-
-# Install rm
-COPY --from=infra-toolkit /busybox/bin/rm /bin/rm
-
-# Install mv
-COPY --from=infra-toolkit /busybox/bin/mv /bin/mv
-
-# Install ln
-COPY --from=infra-toolkit /busybox/bin/ln /bin/ln
-
-# Install vi
-COPY --from=infra-toolkit /busybox/bin/vi /bin/vi
-
-# Add hard links for read-only utils
+# Add hard links for utils
 # Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode
 RUN for b in \
   cat \
@@ -251,10 +236,13 @@ RUN for b in \
   env \
   grep \
   head \
+  jq \
   less \
   ls \
   md5sum \
+  mv \
   pwd \
+  rm \
   sha1sum \
   sha256sum \
   sha3sum \
@@ -265,9 +253,10 @@ RUN for b in \
   tar \
   tee \
   tr \
+  vi \
   watch \
   which \
-  ; do ln sh $b; done
+; do ln sh $b; done
 
 # Install chain binaries
 COPY --from=build-env /root/bin /bin

--- a/dockerfile/cargo/native.Dockerfile
+++ b/dockerfile/cargo/native.Dockerfile
@@ -193,7 +193,6 @@ RUN for b in \
   env \
   grep \
   head \
-  jq \
   less \
   ls \
   md5sum \

--- a/dockerfile/cargo/native.Dockerfile
+++ b/dockerfile/cargo/native.Dockerfile
@@ -160,7 +160,7 @@ RUN bash -c 'set -eux;\
   done'
 
 # Use minimal busybox from infra-toolkit image for final scratch image
-FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.10 AS infra-toolkit
+FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.12 AS infra-toolkit
 RUN addgroup --gid 1025 -S heighliner && adduser --uid 1025 -S heighliner -G heighliner
 
 # Use alpine to source the latest CA certificates
@@ -173,8 +173,10 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install minimal busybox as ln binary (will create hardlinks for the rest of the binaries to this data)
+# Installa minimal busybox as `sh` and `ln` binaries
+# sh allows using `RUN` commands
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
+# ln creates hardlinks for exposed binaries from infra-toolkit min config
 COPY --from=infra-toolkit /busybox/busybox /bin/ln
 
 # Install jq
@@ -198,6 +200,7 @@ RUN for b in \
   mv \
   pwd \
   rm \
+  sed \
   sha1sum \
   sha256sum \
   sha3sum \

--- a/dockerfile/cargo/native.Dockerfile
+++ b/dockerfile/cargo/native.Dockerfile
@@ -173,11 +173,9 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install dirname
-COPY --from=infra-toolkit /usr/bin/dirname /bin/
-
-# Install ln
-COPY --from=infra-toolkit /bin/ln /bin/
+# Install minimal busybox as ln binary (will create hardlinks for the rest of the binaries to this data)
+COPY --from=infra-toolkit /busybox/busybox /bin/sh
+COPY --from=infra-toolkit /busybox/busybox /bin/ln
 
 # Install jq
 COPY --from=infra-toolkit /usr/local/bin/jq /bin/
@@ -196,6 +194,7 @@ RUN for b in \
   less \
   ls \
   md5sum \
+  mkdir \
   mv \
   pwd \
   rm \
@@ -212,8 +211,9 @@ RUN for b in \
   vi \
   watch \
   which \
-  sh \
-  ; do ln ln $b; done
+  ; do ln ln $b; done; \
+  rm -rf sh; \
+  ln ln sh;
 
 # Install chain binaries
 COPY --from=build-env /root/bin /bin

--- a/dockerfile/cargo/native.Dockerfile
+++ b/dockerfile/cargo/native.Dockerfile
@@ -176,9 +176,6 @@ WORKDIR /bin
 # Install dirname
 COPY --from=infra-toolkit /busybox/dirname /bin/dirname
 
-# Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
-COPY --from=infra-toolkit /busybox/busybox /bin/sh
-
 COPY --from=infra-toolkit /busybox/busybox /bin/ln
 
 # Install jq

--- a/dockerfile/cargo/native.Dockerfile
+++ b/dockerfile/cargo/native.Dockerfile
@@ -173,7 +173,7 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Installa minimal busybox as `sh` and `ln` binaries
+# Install a minimal busybox as `sh` and `ln` binaries
 # sh allows using `RUN` commands
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 # ln creates hardlinks for exposed binaries from infra-toolkit min config

--- a/dockerfile/cargo/native.Dockerfile
+++ b/dockerfile/cargo/native.Dockerfile
@@ -173,7 +173,7 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install a minimal busybox as `sh` and `ln` binaries
+# Install minimal busybox as `sh` and `ln` binaries
 # sh allows using `RUN` commands
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 # ln creates hardlinks for exposed binaries from infra-toolkit min config

--- a/dockerfile/cargo/native.Dockerfile
+++ b/dockerfile/cargo/native.Dockerfile
@@ -176,6 +176,11 @@ WORKDIR /bin
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 
+COPY --from=infra-toolkit /busybox/busybox /bin/ln
+
+# Install jq
+COPY --from=infra-toolkit /usr/local/bin/jq /bin/
+
 # Add hard links for utils
 # Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode
 RUN for b in \
@@ -206,7 +211,8 @@ RUN for b in \
   vi \
   watch \
   which \
-; do ln sh $b; done
+  sh \
+  ; do ln ln $b; done
 
 # Install chain binaries
 COPY --from=build-env /root/bin /bin

--- a/dockerfile/cargo/native.Dockerfile
+++ b/dockerfile/cargo/native.Dockerfile
@@ -176,22 +176,7 @@ WORKDIR /bin
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 
-# Install jq
-COPY --from=infra-toolkit /usr/local/bin/jq /bin/
-
-# Install rm
-COPY --from=infra-toolkit /busybox/bin/rm /bin/rm
-
-# Install mv
-COPY --from=infra-toolkit /busybox/bin/mv /bin/mv
-
-# Install ln
-COPY --from=infra-toolkit /busybox/bin/ln /bin/ln
-
-# Install vi
-COPY --from=infra-toolkit /busybox/bin/vi /bin/vi
-
-# Add hard links for read-only utils
+# Add hard links for utils
 # Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode
 RUN for b in \
   cat \
@@ -201,10 +186,13 @@ RUN for b in \
   env \
   grep \
   head \
+  jq \
   less \
   ls \
   md5sum \
+  mv \
   pwd \
+  rm \
   sha1sum \
   sha256sum \
   sha3sum \
@@ -215,9 +203,10 @@ RUN for b in \
   tar \
   tee \
   tr \
+  vi \
   watch \
   which \
-  ; do ln sh $b; done
+; do ln sh $b; done
 
 # Install chain binaries
 COPY --from=build-env /root/bin /bin

--- a/dockerfile/cargo/native.Dockerfile
+++ b/dockerfile/cargo/native.Dockerfile
@@ -163,9 +163,6 @@ RUN bash -c 'set -eux;\
 FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.4 AS infra-toolkit
 RUN addgroup --gid 1025 -S heighliner && adduser --uid 1025 -S heighliner -G heighliner
 
-# Use ln and rm from full featured busybox for assembling final image
-FROM busybox:1.34.1-musl AS busybox-full
-
 # Use alpine to source the latest CA certificates
 FROM alpine:3 as alpine-3
 
@@ -176,14 +173,23 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install ln (for making hard links), rm (for cleanup), mv, mkdir, vi and dirname from full busybox image (will be deleted, only needed for image assembly)
-COPY --from=busybox-full /bin/ln /bin/rm /bin/mv /bin/mkdir /bin/vi /bin/dirname ./
-
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 
 # Install jq
 COPY --from=infra-toolkit /usr/local/bin/jq /bin/
+
+# Install rm
+COPY --from=infra-toolkit /busybox/bin/rm /bin/rm
+
+# Install mv
+COPY --from=infra-toolkit /busybox/bin/mv /bin/mv
+
+# Install ln
+COPY --from=infra-toolkit /busybox/bin/ln /bin/ln
+
+# Install vi
+COPY --from=infra-toolkit /busybox/bin/vi /bin/vi
 
 # Add hard links for read-only utils
 # Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode

--- a/dockerfile/cargo/native.Dockerfile
+++ b/dockerfile/cargo/native.Dockerfile
@@ -173,6 +173,9 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
+# Install dirname
+COPY --from=infra-toolkit /busybox/dirname /bin/dirname
+
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 
@@ -187,6 +190,7 @@ RUN for b in \
   cat \
   date \
   df \
+  dirname \
   du \
   env \
   grep \

--- a/dockerfile/cargo/native.Dockerfile
+++ b/dockerfile/cargo/native.Dockerfile
@@ -160,7 +160,7 @@ RUN bash -c 'set -eux;\
   done'
 
 # Use minimal busybox from infra-toolkit image for final scratch image
-FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.4 AS infra-toolkit
+FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.10 AS infra-toolkit
 RUN addgroup --gid 1025 -S heighliner && adduser --uid 1025 -S heighliner -G heighliner
 
 # Use alpine to source the latest CA certificates
@@ -174,9 +174,10 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 WORKDIR /bin
 
 # Install dirname
-COPY --from=infra-toolkit /busybox/dirname /bin/dirname
+COPY --from=infra-toolkit /usr/bin/dirname /bin/
 
-COPY --from=infra-toolkit /busybox/busybox /bin/ln
+# Install ln
+COPY --from=infra-toolkit /bin/ln /bin/
 
 # Install jq
 COPY --from=infra-toolkit /usr/local/bin/jq /bin/

--- a/dockerfile/cosmos/Dockerfile
+++ b/dockerfile/cosmos/Dockerfile
@@ -167,7 +167,6 @@ RUN for b in \
   env \
   grep \
   head \
-  jq \
   less \
   ls \
   md5sum \

--- a/dockerfile/cosmos/Dockerfile
+++ b/dockerfile/cosmos/Dockerfile
@@ -134,7 +134,7 @@ RUN bash -c 'set -eux;\
   done'
 
 # Use minimal busybox from infra-toolkit image for final scratch image
-FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.4 AS infra-toolkit
+FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.10 AS infra-toolkit
 RUN addgroup --gid 1025 -S heighliner && adduser --uid 1025 -S heighliner -G heighliner
 
 # Use alpine to source the latest CA certificates
@@ -148,9 +148,10 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 WORKDIR /bin
 
 # Install dirname
-COPY --from=infra-toolkit /busybox/dirname /bin/dirname
+COPY --from=infra-toolkit /usr/bin/dirname /bin/
 
-COPY --from=infra-toolkit /busybox/busybox /bin/ln
+# Install ln
+COPY --from=infra-toolkit /bin/ln /bin/
 
 # Install jq
 COPY --from=infra-toolkit /usr/local/bin/jq /bin/

--- a/dockerfile/cosmos/Dockerfile
+++ b/dockerfile/cosmos/Dockerfile
@@ -134,7 +134,7 @@ RUN bash -c 'set -eux;\
   done'
 
 # Use minimal busybox from infra-toolkit image for final scratch image
-FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.10 AS infra-toolkit
+FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.12 AS infra-toolkit
 RUN addgroup --gid 1025 -S heighliner && adduser --uid 1025 -S heighliner -G heighliner
 
 # Use alpine to source the latest CA certificates
@@ -147,8 +147,10 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install minimal busybox as ln binary (will create hardlinks for the rest of the binaries to this data)
+# Installa minimal busybox as `sh` and `ln` binaries
+# sh allows using `RUN` commands
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
+# ln creates hardlinks for exposed binaries from infra-toolkit min config
 COPY --from=infra-toolkit /busybox/busybox /bin/ln
 
 # Install jq
@@ -172,6 +174,7 @@ RUN for b in \
   mv \
   pwd \
   rm \
+  sed \
   sha1sum \
   sha256sum \
   sha3sum \

--- a/dockerfile/cosmos/Dockerfile
+++ b/dockerfile/cosmos/Dockerfile
@@ -180,7 +180,7 @@ RUN for b in \
   vi \
   watch \
   which \
-; do ln sh $b; done
+  ; do ln sh $b; done
 
 # Copy over absolute path directories
 COPY --from=build-env /root/dir_abs /root/dir_abs

--- a/dockerfile/cosmos/Dockerfile
+++ b/dockerfile/cosmos/Dockerfile
@@ -150,22 +150,7 @@ WORKDIR /bin
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 
-# Install jq
-COPY --from=infra-toolkit /usr/local/bin/jq /bin/
-
-# Install rm
-COPY --from=infra-toolkit /busybox/bin/rm /bin/rm
-
-# Install mv
-COPY --from=infra-toolkit /busybox/bin/mv /bin/mv
-
-# Install ln
-COPY --from=infra-toolkit /busybox/bin/ln /bin/ln
-
-# Install vi
-COPY --from=infra-toolkit /busybox/bin/vi /bin/vi
-
-# Add hard links for read-only utils
+# Add hard links for utils
 # Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode
 RUN for b in \
   cat \
@@ -175,10 +160,13 @@ RUN for b in \
   env \
   grep \
   head \
+  jq \
   less \
   ls \
   md5sum \
+  mv \
   pwd \
+  rm \
   sha1sum \
   sha256sum \
   sha3sum \
@@ -189,9 +177,10 @@ RUN for b in \
   tar \
   tee \
   tr \
+  vi \
   watch \
   which \
-  ; do ln sh $b; done
+; do ln sh $b; done
 
 # Copy over absolute path directories
 COPY --from=build-env /root/dir_abs /root/dir_abs
@@ -205,9 +194,6 @@ RUN sh -c 'i=0; while read DIR; do\
       mv /root/dir_abs/$i $DIR;\
       i=$((i+1));\
     done < /root/dir_abs.list'
-
-#  Remove write utils
-RUN rm ln dirname
 
 # Install chain binaries
 COPY --from=build-env /root/bin /bin

--- a/dockerfile/cosmos/Dockerfile
+++ b/dockerfile/cosmos/Dockerfile
@@ -147,7 +147,7 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Installa minimal busybox as `sh` and `ln` binaries
+# Install a minimal busybox as `sh` and `ln` binaries
 # sh allows using `RUN` commands
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 # ln creates hardlinks for exposed binaries from infra-toolkit min config

--- a/dockerfile/cosmos/Dockerfile
+++ b/dockerfile/cosmos/Dockerfile
@@ -147,6 +147,9 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
+# Install dirname
+COPY --from=infra-toolkit /busybox/dirname /bin/dirname
+
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 
@@ -161,6 +164,7 @@ RUN for b in \
   cat \
   date \
   df \
+  dirname \
   du \
   env \
   grep \

--- a/dockerfile/cosmos/Dockerfile
+++ b/dockerfile/cosmos/Dockerfile
@@ -147,7 +147,7 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install a minimal busybox as `sh` and `ln` binaries
+# Install minimal busybox as `sh` and `ln` binaries
 # sh allows using `RUN` commands
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 # ln creates hardlinks for exposed binaries from infra-toolkit min config

--- a/dockerfile/cosmos/Dockerfile
+++ b/dockerfile/cosmos/Dockerfile
@@ -150,9 +150,6 @@ WORKDIR /bin
 # Install dirname
 COPY --from=infra-toolkit /busybox/dirname /bin/dirname
 
-# Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
-COPY --from=infra-toolkit /busybox/busybox /bin/sh
-
 COPY --from=infra-toolkit /busybox/busybox /bin/ln
 
 # Install jq

--- a/dockerfile/cosmos/Dockerfile
+++ b/dockerfile/cosmos/Dockerfile
@@ -137,9 +137,6 @@ RUN bash -c 'set -eux;\
 FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.4 AS infra-toolkit
 RUN addgroup --gid 1025 -S heighliner && adduser --uid 1025 -S heighliner -G heighliner
 
-# Use ln and rm from full featured busybox for assembling final image
-FROM busybox:1.34.1-musl AS busybox-full
-
 # Use alpine to source the latest CA certificates
 FROM alpine:3 as alpine-3
 
@@ -150,14 +147,23 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install ln (for making hard links), rm (for cleanup), mv, mkdir, vi and dirname from full busybox image (will be deleted, only needed for image assembly)
-COPY --from=busybox-full /bin/ln /bin/mv /bin/rm /bin/mkdir /bin/vi /bin/dirname ./
-
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 
 # Install jq
 COPY --from=infra-toolkit /usr/local/bin/jq /bin/
+
+# Install rm
+COPY --from=infra-toolkit /busybox/bin/rm /bin/rm
+
+# Install mv
+COPY --from=infra-toolkit /busybox/bin/mv /bin/mv
+
+# Install ln
+COPY --from=infra-toolkit /busybox/bin/ln /bin/ln
+
+# Install vi
+COPY --from=infra-toolkit /busybox/bin/vi /bin/vi
 
 # Add hard links for read-only utils
 # Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode

--- a/dockerfile/cosmos/Dockerfile
+++ b/dockerfile/cosmos/Dockerfile
@@ -147,11 +147,9 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install dirname
-COPY --from=infra-toolkit /usr/bin/dirname /bin/
-
-# Install ln
-COPY --from=infra-toolkit /bin/ln /bin/
+# Install minimal busybox as ln binary (will create hardlinks for the rest of the binaries to this data)
+COPY --from=infra-toolkit /busybox/busybox /bin/sh
+COPY --from=infra-toolkit /busybox/busybox /bin/ln
 
 # Install jq
 COPY --from=infra-toolkit /usr/local/bin/jq /bin/
@@ -170,6 +168,7 @@ RUN for b in \
   less \
   ls \
   md5sum \
+  mkdir \
   mv \
   pwd \
   rm \
@@ -186,8 +185,9 @@ RUN for b in \
   vi \
   watch \
   which \
-  sh \
-  ; do ln ln $b; done
+  ; do ln ln $b; done; \
+  rm -rf sh; \
+  ln ln sh;
 
 # Copy over absolute path directories
 COPY --from=build-env /root/dir_abs /root/dir_abs

--- a/dockerfile/cosmos/Dockerfile
+++ b/dockerfile/cosmos/Dockerfile
@@ -150,6 +150,11 @@ WORKDIR /bin
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 
+COPY --from=infra-toolkit /busybox/busybox /bin/ln
+
+# Install jq
+COPY --from=infra-toolkit /usr/local/bin/jq /bin/
+
 # Add hard links for utils
 # Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode
 RUN for b in \
@@ -180,7 +185,8 @@ RUN for b in \
   vi \
   watch \
   which \
-  ; do ln sh $b; done
+  sh \
+  ; do ln ln $b; done
 
 # Copy over absolute path directories
 COPY --from=build-env /root/dir_abs /root/dir_abs

--- a/dockerfile/cosmos/local.Dockerfile
+++ b/dockerfile/cosmos/local.Dockerfile
@@ -171,7 +171,7 @@ RUN for b in \
   vi \
   watch \
   which \
-; do ln sh $b; done
+  ; do ln sh $b; done
 
 # Copy over absolute path directories
 COPY --from=build-env /root/dir_abs /root/dir_abs

--- a/dockerfile/cosmos/local.Dockerfile
+++ b/dockerfile/cosmos/local.Dockerfile
@@ -141,9 +141,6 @@ WORKDIR /bin
 # Install dirname
 COPY --from=infra-toolkit /busybox/dirname /bin/dirname
 
-# Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
-COPY --from=infra-toolkit /busybox/busybox /bin/sh
-
 COPY --from=infra-toolkit /busybox/busybox /bin/ln
 
 # Install jq

--- a/dockerfile/cosmos/local.Dockerfile
+++ b/dockerfile/cosmos/local.Dockerfile
@@ -52,9 +52,6 @@ RUN set -eux; \
 FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.4 AS infra-toolkit
 RUN addgroup --gid 1025 -S heighliner && adduser --uid 1025 -S heighliner -G heighliner
 
-# Use ln and rm from full featured busybox for assembling final image
-FROM busybox:1.34.1-musl AS busybox-full
-
 # Use alpine to source the latest CA certificates
 FROM alpine:3 as alpine-3
 
@@ -141,14 +138,24 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install ln (for making hard links), rm (for cleanup), mv, mkdir, vi and dirname from full busybox image (will be deleted, only needed for image assembly)
-COPY --from=busybox-full /bin/ln /bin/mv /bin/rm /bin/mkdir /bin/vi /bin/dirname ./
-
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 
 # Install jq
 COPY --from=infra-toolkit /usr/local/bin/jq /bin/
+
+
+# Install rm
+COPY --from=infra-toolkit /busybox/bin/rm /bin/rm
+
+# Install mv
+COPY --from=infra-toolkit /busybox/bin/mv /bin/mv
+
+# Install ln
+COPY --from=infra-toolkit /busybox/bin/ln /bin/ln
+
+# Install vi
+COPY --from=infra-toolkit /busybox/bin/vi /bin/vi
 
 # Add hard links for read-only utils
 # Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode

--- a/dockerfile/cosmos/local.Dockerfile
+++ b/dockerfile/cosmos/local.Dockerfile
@@ -49,7 +49,7 @@ RUN set -eux; \
     fi;
 
 # Use minimal busybox from infra-toolkit image for final scratch image
-FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.10 AS infra-toolkit
+FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.12 AS infra-toolkit
 RUN addgroup --gid 1025 -S heighliner && adduser --uid 1025 -S heighliner -G heighliner
 
 # Use alpine to source the latest CA certificates
@@ -138,8 +138,10 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install minimal busybox as ln binary (will create hardlinks for the rest of the binaries to this data)
+# Installa minimal busybox as `sh` and `ln` binaries
+# sh allows using `RUN` commands
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
+# ln creates hardlinks for exposed binaries from infra-toolkit min config
 COPY --from=infra-toolkit /busybox/busybox /bin/ln
 
 # Install jq
@@ -163,6 +165,7 @@ RUN for b in \
   mv \
   pwd \
   rm \
+  sed \
   sha1sum \
   sha256sum \
   sha3sum \

--- a/dockerfile/cosmos/local.Dockerfile
+++ b/dockerfile/cosmos/local.Dockerfile
@@ -138,11 +138,9 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install dirname
-COPY --from=infra-toolkit /usr/bin/dirname /bin/
-
-# Install ln
-COPY --from=infra-toolkit /bin/ln /bin/
+# Install minimal busybox as ln binary (will create hardlinks for the rest of the binaries to this data)
+COPY --from=infra-toolkit /busybox/busybox /bin/sh
+COPY --from=infra-toolkit /busybox/busybox /bin/ln
 
 # Install jq
 COPY --from=infra-toolkit /usr/local/bin/jq /bin/
@@ -161,6 +159,7 @@ RUN for b in \
   less \
   ls \
   md5sum \
+  mkdir \
   mv \
   pwd \
   rm \
@@ -177,8 +176,9 @@ RUN for b in \
   vi \
   watch \
   which \
-  sh \
-  ; do ln ln $b; done
+  ; do ln ln $b; done; \
+  rm -rf sh; \
+  ln ln sh;
 
 # Copy over absolute path directories
 COPY --from=build-env /root/dir_abs /root/dir_abs

--- a/dockerfile/cosmos/local.Dockerfile
+++ b/dockerfile/cosmos/local.Dockerfile
@@ -138,6 +138,9 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
+# Install dirname
+COPY --from=infra-toolkit /busybox/dirname /bin/dirname
+
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 
@@ -152,6 +155,7 @@ RUN for b in \
   cat \
   date \
   df \
+  dirname \
   du \
   env \
   grep \

--- a/dockerfile/cosmos/local.Dockerfile
+++ b/dockerfile/cosmos/local.Dockerfile
@@ -138,7 +138,7 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Installa minimal busybox as `sh` and `ln` binaries
+# Install a minimal busybox as `sh` and `ln` binaries
 # sh allows using `RUN` commands
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 # ln creates hardlinks for exposed binaries from infra-toolkit min config

--- a/dockerfile/cosmos/local.Dockerfile
+++ b/dockerfile/cosmos/local.Dockerfile
@@ -141,23 +141,7 @@ WORKDIR /bin
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 
-# Install jq
-COPY --from=infra-toolkit /usr/local/bin/jq /bin/
-
-
-# Install rm
-COPY --from=infra-toolkit /busybox/bin/rm /bin/rm
-
-# Install mv
-COPY --from=infra-toolkit /busybox/bin/mv /bin/mv
-
-# Install ln
-COPY --from=infra-toolkit /busybox/bin/ln /bin/ln
-
-# Install vi
-COPY --from=infra-toolkit /busybox/bin/vi /bin/vi
-
-# Add hard links for read-only utils
+# Add hard links for utils
 # Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode
 RUN for b in \
   cat \
@@ -167,10 +151,13 @@ RUN for b in \
   env \
   grep \
   head \
+  jq \
   less \
   ls \
   md5sum \
+  mv \
   pwd \
+  rm \
   sha1sum \
   sha256sum \
   sha3sum \
@@ -181,9 +168,10 @@ RUN for b in \
   tar \
   tee \
   tr \
+  vi \
   watch \
   which \
-  ; do ln sh $b; done
+; do ln sh $b; done
 
 # Copy over absolute path directories
 COPY --from=build-env /root/dir_abs /root/dir_abs
@@ -197,9 +185,6 @@ RUN sh -c 'i=0; while read DIR; do\
       mv /root/dir_abs/$i $DIR;\
       i=$((i+1));\
     done < /root/dir_abs.list'
-
-# Remove write utils
-RUN rm ln dirname
 
 # Install trusted CA certificates
 COPY --from=alpine-3 /etc/ssl/cert.pem /etc/ssl/cert.pem

--- a/dockerfile/cosmos/local.Dockerfile
+++ b/dockerfile/cosmos/local.Dockerfile
@@ -141,6 +141,11 @@ WORKDIR /bin
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 
+COPY --from=infra-toolkit /busybox/busybox /bin/ln
+
+# Install jq
+COPY --from=infra-toolkit /usr/local/bin/jq /bin/
+
 # Add hard links for utils
 # Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode
 RUN for b in \
@@ -171,7 +176,8 @@ RUN for b in \
   vi \
   watch \
   which \
-  ; do ln sh $b; done
+  sh \
+  ; do ln ln $b; done
 
 # Copy over absolute path directories
 COPY --from=build-env /root/dir_abs /root/dir_abs

--- a/dockerfile/cosmos/local.Dockerfile
+++ b/dockerfile/cosmos/local.Dockerfile
@@ -138,7 +138,7 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install a minimal busybox as `sh` and `ln` binaries
+# Install minimal busybox as `sh` and `ln` binaries
 # sh allows using `RUN` commands
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 # ln creates hardlinks for exposed binaries from infra-toolkit min config

--- a/dockerfile/cosmos/local.Dockerfile
+++ b/dockerfile/cosmos/local.Dockerfile
@@ -49,7 +49,7 @@ RUN set -eux; \
     fi;
 
 # Use minimal busybox from infra-toolkit image for final scratch image
-FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.4 AS infra-toolkit
+FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.10 AS infra-toolkit
 RUN addgroup --gid 1025 -S heighliner && adduser --uid 1025 -S heighliner -G heighliner
 
 # Use alpine to source the latest CA certificates
@@ -139,9 +139,10 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 WORKDIR /bin
 
 # Install dirname
-COPY --from=infra-toolkit /busybox/dirname /bin/dirname
+COPY --from=infra-toolkit /usr/bin/dirname /bin/
 
-COPY --from=infra-toolkit /busybox/busybox /bin/ln
+# Install ln
+COPY --from=infra-toolkit /bin/ln /bin/
 
 # Install jq
 COPY --from=infra-toolkit /usr/local/bin/jq /bin/

--- a/dockerfile/cosmos/local.Dockerfile
+++ b/dockerfile/cosmos/local.Dockerfile
@@ -158,7 +158,6 @@ RUN for b in \
   env \
   grep \
   head \
-  jq \
   less \
   ls \
   md5sum \

--- a/dockerfile/cosmos/localcross.Dockerfile
+++ b/dockerfile/cosmos/localcross.Dockerfile
@@ -175,7 +175,7 @@ RUN for b in \
   vi \
   watch \
   which \
-; do ln sh $b; done
+  ; do ln sh $b; done
 
 # Copy over absolute path directories
 COPY --from=build-env /root/dir_abs /root/dir_abs

--- a/dockerfile/cosmos/localcross.Dockerfile
+++ b/dockerfile/cosmos/localcross.Dockerfile
@@ -142,7 +142,7 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install a minimal busybox as `sh` and `ln` binaries
+# Install minimal busybox as `sh` and `ln` binaries
 # sh allows using `RUN` commands
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 # ln creates hardlinks for exposed binaries from infra-toolkit min config

--- a/dockerfile/cosmos/localcross.Dockerfile
+++ b/dockerfile/cosmos/localcross.Dockerfile
@@ -142,7 +142,7 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Installa minimal busybox as `sh` and `ln` binaries
+# Install a minimal busybox as `sh` and `ln` binaries
 # sh allows using `RUN` commands
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 # ln creates hardlinks for exposed binaries from infra-toolkit min config

--- a/dockerfile/cosmos/localcross.Dockerfile
+++ b/dockerfile/cosmos/localcross.Dockerfile
@@ -142,6 +142,9 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
+# Install dirname
+COPY --from=infra-toolkit /busybox/dirname /bin/dirname
+
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 
@@ -156,6 +159,7 @@ RUN for b in \
   cat \
   date \
   df \
+  dirname \
   du \
   env \
   grep \

--- a/dockerfile/cosmos/localcross.Dockerfile
+++ b/dockerfile/cosmos/localcross.Dockerfile
@@ -145,22 +145,7 @@ WORKDIR /bin
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 
-# Install jq
-COPY --from=infra-toolkit /usr/local/bin/jq /bin/
-
-# Install rm
-COPY --from=infra-toolkit /busybox/bin/rm /bin/rm
-
-# Install mv
-COPY --from=infra-toolkit /busybox/bin/mv /bin/mv
-
-# Install ln
-COPY --from=infra-toolkit /busybox/bin/ln /bin/ln
-
-# Install vi
-COPY --from=infra-toolkit /busybox/bin/vi /bin/vi
-
-# Add hard links for read-only utils
+# Add hard links for utils
 # Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode
 RUN for b in \
   cat \
@@ -170,10 +155,13 @@ RUN for b in \
   env \
   grep \
   head \
+  jq \
   less \
   ls \
   md5sum \
+  mv \
   pwd \
+  rm \
   sha1sum \
   sha256sum \
   sha3sum \
@@ -184,9 +172,10 @@ RUN for b in \
   tar \
   tee \
   tr \
+  vi \
   watch \
   which \
-  ; do ln sh $b; done
+; do ln sh $b; done
 
 # Copy over absolute path directories
 COPY --from=build-env /root/dir_abs /root/dir_abs
@@ -200,9 +189,6 @@ RUN sh -c 'i=0; while read DIR; do\
       mv /root/dir_abs/$i $DIR;\
       i=$((i+1));\
     done < /root/dir_abs.list'
-
-#  Remove write utils
-RUN rm ln dirname
 
 # Install chain binaries
 COPY --from=build-env /root/bin /bin

--- a/dockerfile/cosmos/localcross.Dockerfile
+++ b/dockerfile/cosmos/localcross.Dockerfile
@@ -145,6 +145,11 @@ WORKDIR /bin
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 
+COPY --from=infra-toolkit /busybox/busybox /bin/ln
+
+# Install jq
+COPY --from=infra-toolkit /usr/local/bin/jq /bin/
+
 # Add hard links for utils
 # Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode
 RUN for b in \
@@ -175,7 +180,8 @@ RUN for b in \
   vi \
   watch \
   which \
-  ; do ln sh $b; done
+  sh \
+  ; do ln ln $b; done
 
 # Copy over absolute path directories
 COPY --from=build-env /root/dir_abs /root/dir_abs

--- a/dockerfile/cosmos/localcross.Dockerfile
+++ b/dockerfile/cosmos/localcross.Dockerfile
@@ -129,7 +129,7 @@ RUN bash -c 'set -eux;\
   done'
 
 # Use minimal busybox from infra-toolkit image for final scratch image
-FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.10 AS infra-toolkit
+FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.12 AS infra-toolkit
 RUN addgroup --gid 1025 -S heighliner && adduser --uid 1025 -S heighliner -G heighliner
 
 # Use alpine to source the latest CA certificates
@@ -142,8 +142,10 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install minimal busybox as ln binary (will create hardlinks for the rest of the binaries to this data)
+# Installa minimal busybox as `sh` and `ln` binaries
+# sh allows using `RUN` commands
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
+# ln creates hardlinks for exposed binaries from infra-toolkit min config
 COPY --from=infra-toolkit /busybox/busybox /bin/ln
 
 # Install jq
@@ -167,6 +169,7 @@ RUN for b in \
   mv \
   pwd \
   rm \
+  sed \
   sha1sum \
   sha256sum \
   sha3sum \

--- a/dockerfile/cosmos/localcross.Dockerfile
+++ b/dockerfile/cosmos/localcross.Dockerfile
@@ -132,9 +132,6 @@ RUN bash -c 'set -eux;\
 FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.4 AS infra-toolkit
 RUN addgroup --gid 1025 -S heighliner && adduser --uid 1025 -S heighliner -G heighliner
 
-# Use ln and rm from full featured busybox for assembling final image
-FROM busybox:1.34.1-musl AS busybox-full
-
 # Use alpine to source the latest CA certificates
 FROM alpine:3 as alpine-3
 
@@ -145,14 +142,23 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install ln (for making hard links), rm (for cleanup), mv, mkdir, vi and dirname from full busybox image (will be deleted, only needed for image assembly)
-COPY --from=busybox-full /bin/ln /bin/mv /bin/rm /bin/mkdir /bin/vi /bin/dirname ./
-
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 
 # Install jq
 COPY --from=infra-toolkit /usr/local/bin/jq /bin/
+
+# Install rm
+COPY --from=infra-toolkit /busybox/bin/rm /bin/rm
+
+# Install mv
+COPY --from=infra-toolkit /busybox/bin/mv /bin/mv
+
+# Install ln
+COPY --from=infra-toolkit /busybox/bin/ln /bin/ln
+
+# Install vi
+COPY --from=infra-toolkit /busybox/bin/vi /bin/vi
 
 # Add hard links for read-only utils
 # Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode

--- a/dockerfile/cosmos/localcross.Dockerfile
+++ b/dockerfile/cosmos/localcross.Dockerfile
@@ -162,7 +162,6 @@ RUN for b in \
   env \
   grep \
   head \
-  jq \
   less \
   ls \
   md5sum \

--- a/dockerfile/cosmos/localcross.Dockerfile
+++ b/dockerfile/cosmos/localcross.Dockerfile
@@ -129,7 +129,7 @@ RUN bash -c 'set -eux;\
   done'
 
 # Use minimal busybox from infra-toolkit image for final scratch image
-FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.4 AS infra-toolkit
+FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.10 AS infra-toolkit
 RUN addgroup --gid 1025 -S heighliner && adduser --uid 1025 -S heighliner -G heighliner
 
 # Use alpine to source the latest CA certificates
@@ -143,9 +143,10 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 WORKDIR /bin
 
 # Install dirname
-COPY --from=infra-toolkit /busybox/dirname /bin/dirname
+COPY --from=infra-toolkit /usr/bin/dirname /bin/
 
-COPY --from=infra-toolkit /busybox/busybox /bin/ln
+# Install ln
+COPY --from=infra-toolkit /bin/ln /bin/
 
 # Install jq
 COPY --from=infra-toolkit /usr/local/bin/jq /bin/

--- a/dockerfile/cosmos/localcross.Dockerfile
+++ b/dockerfile/cosmos/localcross.Dockerfile
@@ -142,11 +142,9 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install dirname
-COPY --from=infra-toolkit /usr/bin/dirname /bin/
-
-# Install ln
-COPY --from=infra-toolkit /bin/ln /bin/
+# Install minimal busybox as ln binary (will create hardlinks for the rest of the binaries to this data)
+COPY --from=infra-toolkit /busybox/busybox /bin/sh
+COPY --from=infra-toolkit /busybox/busybox /bin/ln
 
 # Install jq
 COPY --from=infra-toolkit /usr/local/bin/jq /bin/
@@ -165,6 +163,7 @@ RUN for b in \
   less \
   ls \
   md5sum \
+  mkdir \
   mv \
   pwd \
   rm \
@@ -181,8 +180,9 @@ RUN for b in \
   vi \
   watch \
   which \
-  sh \
-  ; do ln ln $b; done
+  ; do ln ln $b; done; \
+  rm -rf sh; \
+  ln ln sh;
 
 # Copy over absolute path directories
 COPY --from=build-env /root/dir_abs /root/dir_abs

--- a/dockerfile/cosmos/localcross.Dockerfile
+++ b/dockerfile/cosmos/localcross.Dockerfile
@@ -145,9 +145,6 @@ WORKDIR /bin
 # Install dirname
 COPY --from=infra-toolkit /busybox/dirname /bin/dirname
 
-# Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
-COPY --from=infra-toolkit /busybox/busybox /bin/sh
-
 COPY --from=infra-toolkit /busybox/busybox /bin/ln
 
 # Install jq

--- a/dockerfile/cosmos/native.Dockerfile
+++ b/dockerfile/cosmos/native.Dockerfile
@@ -123,22 +123,7 @@ WORKDIR /bin
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 
-# Install jq
-COPY --from=infra-toolkit /usr/local/bin/jq /bin/
-
-# Install rm
-COPY --from=infra-toolkit /busybox/bin/rm /bin/rm
-
-# Install mv
-COPY --from=infra-toolkit /busybox/bin/mv /bin/mv
-
-# Install ln
-COPY --from=infra-toolkit /busybox/bin/ln /bin/ln
-
-# Install vi
-COPY --from=infra-toolkit /busybox/bin/vi /bin/vi
-
-# Add hard links for read-only utils
+# Add hard links for utils
 # Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode
 RUN for b in \
   cat \
@@ -148,10 +133,13 @@ RUN for b in \
   env \
   grep \
   head \
+  jq \
   less \
   ls \
   md5sum \
+  mv \
   pwd \
+  rm \
   sha1sum \
   sha256sum \
   sha3sum \
@@ -162,9 +150,10 @@ RUN for b in \
   tar \
   tee \
   tr \
+  vi \
   watch \
   which \
-  ; do ln sh $b; done
+; do ln sh $b; done
 
 # Copy over absolute path directories
 COPY --from=build-env /root/dir_abs /root/dir_abs
@@ -178,9 +167,6 @@ RUN sh -c 'i=0; while read DIR; do\
       mv /root/dir_abs/$i $DIR;\
       i=$((i+1));\
     done < /root/dir_abs.list'
-
-#  Remove write utils
-RUN rm dirname
 
 # Install chain binaries
 COPY --from=build-env /root/bin /bin

--- a/dockerfile/cosmos/native.Dockerfile
+++ b/dockerfile/cosmos/native.Dockerfile
@@ -123,6 +123,11 @@ WORKDIR /bin
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 
+COPY --from=infra-toolkit /busybox/busybox /bin/ln
+
+# Install jq
+COPY --from=infra-toolkit /usr/local/bin/jq /bin/
+
 # Add hard links for utils
 # Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode
 RUN for b in \
@@ -153,7 +158,8 @@ RUN for b in \
   vi \
   watch \
   which \
-  ; do ln sh $b; done
+  sh \
+  ; do ln ln $b; done
 
 # Copy over absolute path directories
 COPY --from=build-env /root/dir_abs /root/dir_abs

--- a/dockerfile/cosmos/native.Dockerfile
+++ b/dockerfile/cosmos/native.Dockerfile
@@ -120,6 +120,9 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
+# Install dirname
+COPY --from=infra-toolkit /busybox/dirname /bin/dirname
+
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 
@@ -134,6 +137,7 @@ RUN for b in \
   cat \
   date \
   df \
+  dirname \
   du \
   env \
   grep \

--- a/dockerfile/cosmos/native.Dockerfile
+++ b/dockerfile/cosmos/native.Dockerfile
@@ -120,7 +120,7 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install a minimal busybox as `sh` and `ln` binaries
+# Install minimal busybox as `sh` and `ln` binaries
 # sh allows using `RUN` commands
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 # ln creates hardlinks for exposed binaries from infra-toolkit min config

--- a/dockerfile/cosmos/native.Dockerfile
+++ b/dockerfile/cosmos/native.Dockerfile
@@ -140,7 +140,6 @@ RUN for b in \
   env \
   grep \
   head \
-  jq \
   less \
   ls \
   md5sum \

--- a/dockerfile/cosmos/native.Dockerfile
+++ b/dockerfile/cosmos/native.Dockerfile
@@ -107,7 +107,7 @@ RUN bash -c 'set -eux;\
   done'
 
 # Use minimal busybox from infra-toolkit image for final scratch image
-FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.10 AS infra-toolkit
+FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.12 AS infra-toolkit
 RUN addgroup --gid 1025 -S heighliner && adduser --uid 1025 -S heighliner -G heighliner
 
 # Use alpine to source the latest CA certificates
@@ -120,8 +120,10 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install minimal busybox as ln binary (will create hardlinks for the rest of the binaries to this data)
+# Installa minimal busybox as `sh` and `ln` binaries
+# sh allows using `RUN` commands
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
+# ln creates hardlinks for exposed binaries from infra-toolkit min config
 COPY --from=infra-toolkit /busybox/busybox /bin/ln
 
 # Install jq
@@ -145,6 +147,7 @@ RUN for b in \
   mv \
   pwd \
   rm \
+  sed \
   sha1sum \
   sha256sum \
   sha3sum \

--- a/dockerfile/cosmos/native.Dockerfile
+++ b/dockerfile/cosmos/native.Dockerfile
@@ -107,7 +107,7 @@ RUN bash -c 'set -eux;\
   done'
 
 # Use minimal busybox from infra-toolkit image for final scratch image
-FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.4 AS infra-toolkit
+FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.10 AS infra-toolkit
 RUN addgroup --gid 1025 -S heighliner && adduser --uid 1025 -S heighliner -G heighliner
 
 # Use alpine to source the latest CA certificates
@@ -121,9 +121,10 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 WORKDIR /bin
 
 # Install dirname
-COPY --from=infra-toolkit /busybox/dirname /bin/dirname
+COPY --from=infra-toolkit /usr/bin/dirname /bin/
 
-COPY --from=infra-toolkit /busybox/busybox /bin/ln
+# Install ln
+COPY --from=infra-toolkit /bin/ln /bin/
 
 # Install jq
 COPY --from=infra-toolkit /usr/local/bin/jq /bin/

--- a/dockerfile/cosmos/native.Dockerfile
+++ b/dockerfile/cosmos/native.Dockerfile
@@ -153,7 +153,7 @@ RUN for b in \
   vi \
   watch \
   which \
-; do ln sh $b; done
+  ; do ln sh $b; done
 
 # Copy over absolute path directories
 COPY --from=build-env /root/dir_abs /root/dir_abs

--- a/dockerfile/cosmos/native.Dockerfile
+++ b/dockerfile/cosmos/native.Dockerfile
@@ -123,9 +123,6 @@ WORKDIR /bin
 # Install dirname
 COPY --from=infra-toolkit /busybox/dirname /bin/dirname
 
-# Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
-COPY --from=infra-toolkit /busybox/busybox /bin/sh
-
 COPY --from=infra-toolkit /busybox/busybox /bin/ln
 
 # Install jq

--- a/dockerfile/cosmos/native.Dockerfile
+++ b/dockerfile/cosmos/native.Dockerfile
@@ -120,7 +120,7 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Installa minimal busybox as `sh` and `ln` binaries
+# Install a minimal busybox as `sh` and `ln` binaries
 # sh allows using `RUN` commands
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 # ln creates hardlinks for exposed binaries from infra-toolkit min config

--- a/dockerfile/cosmos/native.Dockerfile
+++ b/dockerfile/cosmos/native.Dockerfile
@@ -120,11 +120,9 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install dirname
-COPY --from=infra-toolkit /usr/bin/dirname /bin/
-
-# Install ln
-COPY --from=infra-toolkit /bin/ln /bin/
+# Install minimal busybox as ln binary (will create hardlinks for the rest of the binaries to this data)
+COPY --from=infra-toolkit /busybox/busybox /bin/sh
+COPY --from=infra-toolkit /busybox/busybox /bin/ln
 
 # Install jq
 COPY --from=infra-toolkit /usr/local/bin/jq /bin/
@@ -143,6 +141,7 @@ RUN for b in \
   less \
   ls \
   md5sum \
+  mkdir \
   mv \
   pwd \
   rm \
@@ -159,8 +158,9 @@ RUN for b in \
   vi \
   watch \
   which \
-  sh \
-  ; do ln ln $b; done
+  ; do ln ln $b; done; \
+  rm -rf sh; \
+  ln ln sh;
 
 # Copy over absolute path directories
 COPY --from=build-env /root/dir_abs /root/dir_abs

--- a/dockerfile/cosmos/native.Dockerfile
+++ b/dockerfile/cosmos/native.Dockerfile
@@ -110,9 +110,6 @@ RUN bash -c 'set -eux;\
 FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.4 AS infra-toolkit
 RUN addgroup --gid 1025 -S heighliner && adduser --uid 1025 -S heighliner -G heighliner
 
-# Use ln and rm from full featured busybox for assembling final image
-FROM busybox:1.34.1-musl AS busybox-full
-
 # Use alpine to source the latest CA certificates
 FROM alpine:3 as alpine-3
 
@@ -123,14 +120,23 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install ln (for making hard links), rm (for cleanup), mv, mkdir, vi and dirname from full busybox image (will be deleted, only needed for image assembly)
-COPY --from=busybox-full /bin/ln /bin/mv /bin/rm /bin/mkdir /bin/vi /bin/dirname ./
-
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 
 # Install jq
 COPY --from=infra-toolkit /usr/local/bin/jq /bin/
+
+# Install rm
+COPY --from=infra-toolkit /busybox/bin/rm /bin/rm
+
+# Install mv
+COPY --from=infra-toolkit /busybox/bin/mv /bin/mv
+
+# Install ln
+COPY --from=infra-toolkit /busybox/bin/ln /bin/ln
+
+# Install vi
+COPY --from=infra-toolkit /busybox/bin/vi /bin/vi
 
 # Add hard links for read-only utils
 # Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode

--- a/dockerfile/imported/Dockerfile
+++ b/dockerfile/imported/Dockerfile
@@ -124,7 +124,7 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install a minimal busybox as `sh` and `ln` binaries
+# Install minimal busybox as `sh` and `ln` binaries
 # sh allows using `RUN` commands
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 # ln creates hardlinks for exposed binaries from infra-toolkit min config

--- a/dockerfile/imported/Dockerfile
+++ b/dockerfile/imported/Dockerfile
@@ -6,9 +6,6 @@ FROM $BASE_IMAGE:$VERSION AS imported
 FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.4 AS infra-toolkit
 RUN addgroup --gid 1025 -S heighliner && adduser --uid 1025 -S heighliner -G heighliner
 
-# Use ln and rm from full featured busybox for assembling final image
-FROM busybox:1.34.1-musl AS busybox-full
-
 # Use alpine to source the latest CA certificates
 FROM alpine:3 as alpine-3
 
@@ -127,14 +124,23 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install ln (for making hard links), rm (for cleanup), mv, mkdir, vi and dirname from full busybox image (will be deleted, only needed for image assembly)
-COPY --from=busybox-full /bin/ln /bin/mv /bin/rm /bin/mkdir /bin/vi /bin/dirname ./
-
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 
 # Install jq
 COPY --from=infra-toolkit /usr/local/bin/jq /bin/
+
+# Install rm
+COPY --from=infra-toolkit /busybox/bin/rm /bin/rm
+
+# Install mv
+COPY --from=infra-toolkit /busybox/bin/mv /bin/mv
+
+# Install ln
+COPY --from=infra-toolkit /busybox/bin/ln /bin/ln
+
+# Install vi
+COPY --from=infra-toolkit /busybox/bin/vi /bin/vi
 
 # Add hard links for read-only utils
 # Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode

--- a/dockerfile/imported/Dockerfile
+++ b/dockerfile/imported/Dockerfile
@@ -127,22 +127,7 @@ WORKDIR /bin
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 
-# Install jq
-COPY --from=infra-toolkit /usr/local/bin/jq /bin/
-
-# Install rm
-COPY --from=infra-toolkit /busybox/bin/rm /bin/rm
-
-# Install mv
-COPY --from=infra-toolkit /busybox/bin/mv /bin/mv
-
-# Install ln
-COPY --from=infra-toolkit /busybox/bin/ln /bin/ln
-
-# Install vi
-COPY --from=infra-toolkit /busybox/bin/vi /bin/vi
-
-# Add hard links for read-only utils
+# Add hard links utils
 # Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode
 RUN for b in \
   cat \
@@ -152,10 +137,13 @@ RUN for b in \
   env \
   grep \
   head \
+  jq \
   less \
   ls \
   md5sum \
+  mv \
   pwd \
+  rm \
   sha1sum \
   sha256sum \
   sha3sum \
@@ -166,9 +154,10 @@ RUN for b in \
   tar \
   tee \
   tr \
+  vi \
   watch \
   which \
-  ; do ln sh $b; done
+; do ln sh $b; done
 
 # Install chain binaries
 COPY --from=build-env /root/bin /bin

--- a/dockerfile/imported/Dockerfile
+++ b/dockerfile/imported/Dockerfile
@@ -144,7 +144,6 @@ RUN for b in \
   env \
   grep \
   head \
-  jq \
   less \
   ls \
   md5sum \

--- a/dockerfile/imported/Dockerfile
+++ b/dockerfile/imported/Dockerfile
@@ -124,7 +124,7 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Installa minimal busybox as `sh` and `ln` binaries
+# Install a minimal busybox as `sh` and `ln` binaries
 # sh allows using `RUN` commands
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 # ln creates hardlinks for exposed binaries from infra-toolkit min config

--- a/dockerfile/imported/Dockerfile
+++ b/dockerfile/imported/Dockerfile
@@ -3,7 +3,7 @@ ARG VERSION
 FROM $BASE_IMAGE:$VERSION AS imported
 
 # Use minimal busybox from infra-toolkit image for final scratch image
-FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.4 AS infra-toolkit
+FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.10 AS infra-toolkit
 RUN addgroup --gid 1025 -S heighliner && adduser --uid 1025 -S heighliner -G heighliner
 
 # Use alpine to source the latest CA certificates
@@ -125,9 +125,10 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 WORKDIR /bin
 
 # Install dirname
-COPY --from=infra-toolkit /busybox/dirname /bin/dirname
+COPY --from=infra-toolkit /usr/bin/dirname /bin/
 
-COPY --from=infra-toolkit /busybox/busybox /bin/ln
+# Install ln
+COPY --from=infra-toolkit /bin/ln /bin/
 
 # Install jq
 COPY --from=infra-toolkit /usr/local/bin/jq /bin/

--- a/dockerfile/imported/Dockerfile
+++ b/dockerfile/imported/Dockerfile
@@ -127,9 +127,6 @@ WORKDIR /bin
 # Install dirname
 COPY --from=infra-toolkit /busybox/dirname /bin/dirname
 
-# Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
-COPY --from=infra-toolkit /busybox/busybox /bin/sh
-
 COPY --from=infra-toolkit /busybox/busybox /bin/ln
 
 # Install jq

--- a/dockerfile/imported/Dockerfile
+++ b/dockerfile/imported/Dockerfile
@@ -124,11 +124,11 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install dirname
-COPY --from=infra-toolkit /usr/bin/dirname /bin/
+# Install minimal busybox as ln binary (will create hardlinks for the rest of the binaries to this data)
+COPY --from=infra-toolkit /busybox/busybox /bin/sh
+COPY --from=infra-toolkit /busybox/busybox /bin/ln
 
-# Install ln
-COPY --from=infra-toolkit /bin/ln /bin/
+COPY --from=infra-toolkit /busybox/busybox /bin/sh
 
 # Install jq
 COPY --from=infra-toolkit /usr/local/bin/jq /bin/
@@ -147,6 +147,7 @@ RUN for b in \
   less \
   ls \
   md5sum \
+  mkdir \
   mv \
   pwd \
   rm \
@@ -163,8 +164,9 @@ RUN for b in \
   vi \
   watch \
   which \
-  sh \
-  ; do ln ln $b; done
+  ; do ln ln $b; done; \
+  rm -rf sh; \
+  ln ln sh;
 
 # Install chain binaries
 COPY --from=build-env /root/bin /bin

--- a/dockerfile/imported/Dockerfile
+++ b/dockerfile/imported/Dockerfile
@@ -124,6 +124,9 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
+# Install dirname
+COPY --from=infra-toolkit /busybox/dirname /bin/dirname
+
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 
@@ -138,6 +141,7 @@ RUN for b in \
   cat \
   date \
   df \
+  dirname \
   du \
   env \
   grep \

--- a/dockerfile/imported/Dockerfile
+++ b/dockerfile/imported/Dockerfile
@@ -127,6 +127,11 @@ WORKDIR /bin
 # Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 
+COPY --from=infra-toolkit /busybox/busybox /bin/ln
+
+# Install jq
+COPY --from=infra-toolkit /usr/local/bin/jq /bin/
+
 # Add hard links utils
 # Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode
 RUN for b in \
@@ -157,7 +162,8 @@ RUN for b in \
   vi \
   watch \
   which \
-  ; do ln sh $b; done
+  sh \
+  ; do ln ln $b; done
 
 # Install chain binaries
 COPY --from=build-env /root/bin /bin

--- a/dockerfile/imported/Dockerfile
+++ b/dockerfile/imported/Dockerfile
@@ -128,8 +128,6 @@ WORKDIR /bin
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
 COPY --from=infra-toolkit /busybox/busybox /bin/ln
 
-COPY --from=infra-toolkit /busybox/busybox /bin/sh
-
 # Install jq
 COPY --from=infra-toolkit /usr/local/bin/jq /bin/
 

--- a/dockerfile/imported/Dockerfile
+++ b/dockerfile/imported/Dockerfile
@@ -3,7 +3,7 @@ ARG VERSION
 FROM $BASE_IMAGE:$VERSION AS imported
 
 # Use minimal busybox from infra-toolkit image for final scratch image
-FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.10 AS infra-toolkit
+FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.12 AS infra-toolkit
 RUN addgroup --gid 1025 -S heighliner && adduser --uid 1025 -S heighliner -G heighliner
 
 # Use alpine to source the latest CA certificates
@@ -124,8 +124,10 @@ LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/h
 
 WORKDIR /bin
 
-# Install minimal busybox as ln binary (will create hardlinks for the rest of the binaries to this data)
+# Installa minimal busybox as `sh` and `ln` binaries
+# sh allows using `RUN` commands
 COPY --from=infra-toolkit /busybox/busybox /bin/sh
+# ln creates hardlinks for exposed binaries from infra-toolkit min config
 COPY --from=infra-toolkit /busybox/busybox /bin/ln
 
 # Install jq
@@ -149,6 +151,7 @@ RUN for b in \
   mv \
   pwd \
   rm \
+  sed \
   sha1sum \
   sha256sum \
   sha3sum \

--- a/dockerfile/imported/Dockerfile
+++ b/dockerfile/imported/Dockerfile
@@ -157,7 +157,7 @@ RUN for b in \
   vi \
   watch \
   which \
-; do ln sh $b; done
+  ; do ln sh $b; done
 
 # Install chain binaries
 COPY --from=build-env /root/bin /bin


### PR DESCRIPTION
## Description
This PR is for removing busybox-full to fix the possible exposure to vulnerabilities through having utilities


## Changes
- Remove busybox-full image
- Update Dockerfile to copy core utilities (rm, mv, ln, vi, jq) from the custom BusyBox build in infra-toolkit.
- Ensure that all binaries (except jq and specific chain binaries) share the same inode, meaning they are hard links to a single minimal busybox binary.
- Save disk space and limit exposure to unnecessary utilities.

## Tests
- N/A

## Checklist

- [x] This PR should be merged after https://github.com/strangelove-ventures/infra-toolkit/pull/20
    - The new infra-toolkit Image  will be used in the Dockerfile ( it will have the binaries )

# Docs

**Busybox Hardlink Optimization & Security Considerations**

### **Objective**
The goal is to ensure that all binaries (except `jq` and chain-specific binaries) are hard links to a single minimal `busybox` binary. This helps to:
- Reduce disk space usage.
- Restrict the number of exposed utilities.
- Improve security by preventing unintended command execution.

### **Background**
Busybox operates by invoking different utilities based on the name of the binary that links to it. If the full version of `busybox` is used, all included utilities become accessible. This introduces a security risk if unnecessary utilities are available in the container.

### **Issues Identified**
1. **Inode Inconsistencies**
   - Expected: Most of the binaries (except `jq` and `uniond`) should have the same inode, indicating they are hard links to the same file.
   - Unexpected: `rm`, `vi`, `mv`, `mkdir`, and `dirname` had different inodes.
   
2. **Presence of Busybox Full**
   - The current `busybox` version appears to be the full version instead of the minimal version.
   - Running `busybox su` confirms that unnecessary utilities are included, which is a security risk/concern.
   
3. **Security Concerns**
   - With `busybox full`, any additional utility can be executed simply by creating a hard link.
   - A previous security audit on Heighliner recommended limiting the number of utilities in the image.

4. **Disk Space Usage**
   - Currently, rm, mv, and mkdir are separate copies of the binary instead of hard links.
   - This redundancy increases disk space usage unnecessarily.

### **Steps to Fix the Issues**
1. **Ensure Hard Links for Required Binaries**
   - Verify inode consistency using `ls -i`.
   - Ensure most of the binaries are hard links to the minimal `busybox` binary.

2. **Rebuild Busybox as a Minimal Version**
   - Configure `busybox` with only required utilities using own busybox.min.config.
   - Test to confirm that unnecessary utilities are not included.

3. **Reduce Disk/Image Space**
   - Optimizing by using hard links ensures only a single copy of busybox is stored.   

