### PR TITLE
fix: penumbra build for v1.5.0

### DIFF
--- a/chains/penumbra.yaml
+++ b/chains/penumbra.yaml
@@ -3,7 +3,7 @@
   github-organization: penumbra-zone
   github-repo: penumbra
   dockerfile: cargo
-  build-target: cargo build --release
+  build-target: cargo build --release --bins
   pre-build: |
     apt install -y git-lfs
     git lfs fetch


### PR DESCRIPTION
The upstream release of Penumbra v1.5.0 [0] introduced optional USB dependencies in their Rust workspace, as part of Ledger support. Although the relevant USB-consuming features are off by default, running `cargo build --release` will build all crates in the workspace, including the new Ledger crates, even though they're not used in any binaries by default. Instead, let's use `cargo build --release --bins` in the heighliner config, so that strict dependency resolution is used within the Penumbra workspace, ensuring that the disabled features are not enabled.

[0] https://github.com/penumbra-zone/penumbra/releases/tag/v1.5.0