### PR TITLE
builder: tolerate Go 1.24+ `tool` directive in go.mod parsing

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -224,7 +224,11 @@ func getModFile(
 		}
 	}
 
-	goMod, err := modfile.Parse("go.mod", goModBz, nil)
+	// ParseLax ignores unknown directives (e.g. the Go 1.24+ `tool` directive
+	// unknown to the pinned golang.org/x/mod) while still populating `go` and
+	// `require`, which are the only fields used downstream for Go version
+	// selection and wasmvm version detection.
+	goMod, err := modfile.ParseLax("go.mod", goModBz, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse go.mod file: %w", err)
 	}


### PR DESCRIPTION
## Problem

For chains using `dockerfile: cosmos` (and `avalanche`), `getModFile` in `builder/builder.go` clones the target repo's `go.mod` and parses it with strict `modfile.Parse` to extract:

- the Go version — used by `GetImageAndVersionForGoVersion` to pick the builder image
- wasmvm `require`/`replace` entries — used by `getWasmvmVersion`

Heighliner currently pins `golang.org/x/mod v0.17.0`, which predates the `tool` directive introduced in Go 1.24. Modern cosmos-SDK chains have begun adopting `tool` (to declare dev tools like `golangci-lint`), which causes strict parsing to error out:

```
error getting mod file: failed to parse go.mod file: go.mod:NNN: unknown directive: tool
panic: Some images failed to build
```

This reproduces on **celestia-app v8.0.3** (`tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint` at `go.mod:461`), and will surface on any other chain that adopts the directive.

## Fix

Swap `modfile.Parse` → `modfile.ParseLax` in `getModFile` (one-line change).

`ParseLax` silently ignores statements it doesn't know about, but still populates `go` and `require` — the only fields consumed downstream. Behaviour for existing chains is unchanged, including chains that use wasmvm/CosmWasm.

## Verification

Reproduction with `golang.org/x/mod v0.17.0` (the version heighliner pins) against a synthetic go.mod that contains both a `tool` directive and a wasmvm `require`:

```
Parse (strict) failed: go.mod:7: unknown directive: tool
ParseLax OK: go=1.25.7, requires=1
  - github.com/CosmWasm/wasmvm/v2 v2.1.3
```

`go test ./builder/...` continues to pass; no dependency or go.mod changes needed.

## Alternatives considered

- **Bump `golang.org/x/mod`** — heavier change, and would require tracking the module going forward for every new Go directive. ParseLax future-proofs against this entire class of issue without needing to know about each new directive.
- **Manual go.mod fallback** (catch the strict-parse error, re-extract the Go version from text) — loses the `require` information, so wasmvm detection would stop working for any chain that ever hits a future unknown directive.