### PR TITLE
feat: add BuildKit private Git authentication

### DIFF
--- a/.github/workflows/buildkit-integration.yml
+++ b/.github/workflows/buildkit-integration.yml
@@ -1,0 +1,46 @@
+name: BuildKit integration
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  buildkit-auth-session:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "1.23"
+
+      - name: Start BuildKit v0.12.5
+        run: >-
+          docker run --detach --rm --privileged
+          --name heighliner-buildkit
+          --publish 127.0.0.1:1234:1234
+          moby/buildkit:v0.12.5
+          --allow-insecure-entitlement network.host
+          --addr tcp://0.0.0.0:1234
+
+      - name: Wait for BuildKit
+        run: |
+          for attempt in $(seq 1 30); do
+            if docker logs heighliner-buildkit 2>&1 | grep -q "running server"; then
+              exit 0
+            fi
+            sleep 1
+          done
+          docker logs heighliner-buildkit
+          exit 1
+
+      - name: Verify ephemeral authentication mounts
+        env:
+          BUILDKIT_ADDR: tcp://127.0.0.1:1234
+        run: go test ./docker -run '^TestBuildKitAuthenticationSessionMounts$' -count=1 -v
+
+      - name: Stop BuildKit
+        if: always()
+        run: docker stop heighliner-buildkit || true

--- a/README.md
+++ b/README.md
@@ -140,6 +140,24 @@ The build will look for the local buildkit unix socket by default. Change addres
 
 Customize the platform(s) to be built with the `--platform` flag.
 
+### Private Git authentication
+
+Private Git authentication is available for BuildKit Cosmos builds. Choose one mode:
+
+- `--ssh` forwards the agent at `SSH_AUTH_SOCK`.
+- `--github-auth` reads a GitHub token from `GH_TOKEN`, then `GITHUB_TOKEN`.
+- `--clone-key-env <name>` reads the deprecated base64 key format without placing it in a build argument or image layer.
+
+SSH modes require `--ssh-known-hosts <path>`, `SSH_KNOWN_HOSTS`, or `~/.ssh/known_hosts`. Authentication is validated before network access.
+
+```shell
+heighliner build -b --ssh -c gaia -g private-branch
+export GH_TOKEN=github_app_installation_token
+heighliner build -b --github-auth -c gaia -g private-branch
+```
+
+The existing `--clone-key` flag and YAML property remain compatible but deprecated. BuildKit converts the key to an SSH session; non-BuildKit builds retain the insecure legacy path with a warning. Workflow actions must explicitly forward the selected environment variable.
+
 #### Example: build x64 and arm64 docker images for gaia v7.0.1:
 
 ```shell
@@ -155,4 +173,3 @@ heighliner build -b --buildkit-addr tcp://192.168.1.5:8125 -c gaia -g v7.0.1 -r 
 ```
 
 Docker images for `heighliner/gaia:v7.0.1` will be built on the remote buildkit server and then pushed to the container repository. The manifest for the tag will contain both amd64 and arm64 images.
-

--- a/builder/auth.go
+++ b/builder/auth.go
@@ -1,0 +1,223 @@
+package builder
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	gitssh "github.com/go-git/go-git/v5/plumbing/transport/ssh"
+	"github.com/strangelove-ventures/heighliner/docker"
+)
+
+type GitAuthMode string
+
+const (
+	GitAuthModeNone        GitAuthMode = "none"
+	GitAuthModeSSH         GitAuthMode = "ssh"
+	GitAuthModeGitHubToken GitAuthMode = "github-token"
+	githubTokenEnv         string      = "GH_TOKEN"
+	githubActionsTokenEnv  string      = "GITHUB_TOKEN"
+)
+
+type GitAuthConfig struct {
+	Mode                GitAuthMode
+	SSHAgentSocket      string
+	SSHPrivateKey       []byte
+	SSHKnownHosts       []byte
+	SSHKnownHostsPaths  []string
+	GitHubToken         string
+	InsecureLegacyClone bool
+}
+
+func (a GitAuthConfig) Netrc() []byte {
+	if a.Mode != GitAuthModeGitHubToken {
+		return nil
+	}
+	return []byte(fmt.Sprintf("machine github.com\nlogin x-access-token\npassword %s\n", a.GitHubToken))
+}
+
+func ResolveGitAuth(buildConfig HeighlinerDockerBuildConfig, chainConfig ChainNodeConfig) (GitAuthConfig, error) {
+	return resolveGitAuth(buildConfig, chainConfig, os.Stat)
+}
+
+func resolveGitAuth(
+	buildConfig HeighlinerDockerBuildConfig,
+	chainConfig ChainNodeConfig,
+	stat func(string) (os.FileInfo, error),
+) (GitAuthConfig, error) {
+	repoHost := chainConfig.RepoHost
+	if repoHost == "" {
+		repoHost = "github.com"
+	}
+
+	sources := 0
+	if buildConfig.UseSSH {
+		sources++
+	}
+	if buildConfig.UseGitHubAuth {
+		sources++
+	}
+	if buildConfig.CloneKeyEnv != "" {
+		sources++
+	}
+	if chainConfig.CloneKey != "" {
+		sources++
+	}
+	if sources > 1 {
+		return GitAuthConfig{}, errors.New("private Git authentication options are mutually exclusive")
+	}
+	usesSSH := buildConfig.UseSSH || buildConfig.CloneKeyEnv != "" || chainConfig.CloneKey != ""
+	if buildConfig.SSHKnownHostsPath != "" && !usesSSH {
+		return GitAuthConfig{}, errors.New("--ssh-known-hosts requires SSH authentication")
+	}
+	if sources == 0 {
+		return GitAuthConfig{Mode: GitAuthModeNone}, nil
+	}
+
+	usesNewOption := buildConfig.UseSSH || buildConfig.SSHKnownHostsPath != "" || buildConfig.UseGitHubAuth || buildConfig.CloneKeyEnv != ""
+	if usesNewOption && !buildConfig.UseBuildKit {
+		return GitAuthConfig{}, errors.New("--ssh, --ssh-known-hosts, --github-auth, and --clone-key-env require --use-buildkit")
+	}
+	if usesNewOption && !isCosmosDockerfile(chainConfig) {
+		return GitAuthConfig{}, errors.New("new private Git authentication options currently support only Cosmos Dockerfiles")
+	}
+
+	if buildConfig.UseGitHubAuth {
+		if repoHost != "github.com" {
+			return GitAuthConfig{}, fmt.Errorf("GitHub token authentication only supports github.com repositories, got %q", repoHost)
+		}
+
+		token := os.Getenv(githubTokenEnv)
+		if token == "" {
+			token = os.Getenv(githubActionsTokenEnv)
+		}
+		if token == "" {
+			return GitAuthConfig{}, errors.New("--github-auth requires GH_TOKEN or GITHUB_TOKEN to be set and non-empty")
+		}
+		if strings.ContainsAny(token, "\r\n") {
+			return GitAuthConfig{}, errors.New("GitHub token environment variable contains a newline")
+		}
+		return GitAuthConfig{Mode: GitAuthModeGitHubToken, GitHubToken: token}, nil
+	}
+
+	auth := GitAuthConfig{Mode: GitAuthModeSSH}
+	if buildConfig.UseSSH {
+		auth.SSHAgentSocket = os.Getenv("SSH_AUTH_SOCK")
+		if auth.SSHAgentSocket == "" {
+			return GitAuthConfig{}, errors.New("--ssh requires SSH_AUTH_SOCK to be set")
+		}
+		info, err := stat(auth.SSHAgentSocket)
+		if err != nil {
+			return GitAuthConfig{}, fmt.Errorf("cannot access SSH agent socket %q: %w", auth.SSHAgentSocket, err)
+		}
+		if info.Mode()&os.ModeSocket == 0 {
+			return GitAuthConfig{}, fmt.Errorf("SSH_AUTH_SOCK %q is not a Unix socket", auth.SSHAgentSocket)
+		}
+	} else {
+		encodedKey := chainConfig.CloneKey
+		if buildConfig.CloneKeyEnv != "" {
+			encodedKey = os.Getenv(buildConfig.CloneKeyEnv)
+			if encodedKey == "" {
+				return GitAuthConfig{}, fmt.Errorf("clone key environment variable %q is not set or empty", buildConfig.CloneKeyEnv)
+			}
+		}
+
+		privateKey, err := base64.StdEncoding.DecodeString(encodedKey)
+		if err != nil {
+			return GitAuthConfig{}, errors.New("failed to decode clone key")
+		}
+		if _, err := gitssh.NewPublicKeys("git", privateKey, ""); err != nil {
+			return GitAuthConfig{}, errors.New("failed to parse clone key")
+		}
+		auth.SSHPrivateKey = privateKey
+	}
+
+	if !buildConfig.UseBuildKit && chainConfig.CloneKey != "" {
+		auth.InsecureLegacyClone = true
+		return auth, nil
+	}
+
+	paths, contents, err := resolveKnownHosts(buildConfig.SSHKnownHostsPath)
+	if err != nil {
+		return GitAuthConfig{}, err
+	}
+	auth.SSHKnownHostsPaths = paths
+	auth.SSHKnownHosts = contents
+	return auth, nil
+}
+
+func isCosmosDockerfile(chainConfig ChainNodeConfig) bool {
+	dockerfile := chainConfig.Dockerfile
+	if dockerfile == "" {
+		dockerfile = chainConfig.Language
+	}
+	return dockerfile == DockerfileTypeCosmos || dockerfile == DockerfileTypeGo
+}
+
+func resolveKnownHosts(explicitPath string) ([]string, []byte, error) {
+	knownHostsPath := explicitPath
+	if knownHostsPath == "" {
+		knownHostsPath = os.Getenv("SSH_KNOWN_HOSTS")
+	}
+	if knownHostsPath == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, nil, fmt.Errorf("cannot locate ~/.ssh/known_hosts: %w", err)
+		}
+		knownHostsPath = filepath.Join(home, ".ssh", "known_hosts")
+	}
+
+	paths := filepath.SplitList(knownHostsPath)
+	var contents []byte
+	for _, knownHostsFile := range paths {
+		if knownHostsFile == "" {
+			continue
+		}
+		entry, err := os.ReadFile(knownHostsFile)
+		if err != nil {
+			return nil, nil, fmt.Errorf("cannot read SSH known_hosts file %q: %w", knownHostsFile, err)
+		}
+		contents = append(contents, entry...)
+		if len(contents) > 0 && contents[len(contents)-1] != '\n' {
+			contents = append(contents, '\n')
+		}
+	}
+	if len(paths) == 0 || len(contents) == 0 {
+		return nil, nil, errors.New("SSH authentication requires a non-empty known_hosts file")
+	}
+	return paths, contents, nil
+}
+
+func CloneKeyDeprecationWarnings(buildConfig HeighlinerDockerBuildConfig, chainConfig ChainNodeConfig) []string {
+	if chainConfig.CloneKey == "" {
+		return nil
+	}
+	warnings := []string{"Warning: --clone-key and YAML clone-key are deprecated; use --ssh or --clone-key-env instead."}
+	if !buildConfig.UseBuildKit {
+		warnings = append(warnings, "Warning: non-BuildKit clone-key authentication uses the insecure legacy image-layer path; use --use-buildkit.")
+	}
+	return warnings
+}
+
+func gitAuthBuildConfig(useBuildKit bool, legacyCloneKey string, auth GitAuthConfig) (map[string]string, docker.BuildKitSessionOptions) {
+	args := map[string]string{"GIT_AUTH_MODE": string(auth.Mode)}
+	if !useBuildKit {
+		args["CLONE_KEY"] = legacyCloneKey
+	}
+
+	sessionOptions := docker.BuildKitSessionOptions{
+		SSHAgentSocket: auth.SSHAgentSocket,
+		SSHPrivateKey:  auth.SSHPrivateKey,
+		Secrets:        map[string][]byte{},
+	}
+	if len(auth.SSHKnownHosts) != 0 {
+		sessionOptions.Secrets[docker.GitKnownHostsSecretID] = auth.SSHKnownHosts
+	}
+	if netrc := auth.Netrc(); len(netrc) != 0 {
+		sessionOptions.Secrets[docker.GitNetrcSecretID] = netrc
+	}
+	return args, sessionOptions
+}

--- a/builder/auth_test.go
+++ b/builder/auth_test.go
@@ -1,0 +1,219 @@
+package builder
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
+	gitssh "github.com/go-git/go-git/v5/plumbing/transport/ssh"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+func testCloneKey(t *testing.T) string {
+	t.Helper()
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	block, err := ssh.MarshalPrivateKey(privateKey, "heighliner-test")
+	require.NoError(t, err)
+	return base64.StdEncoding.EncodeToString(pem.EncodeToMemory(block))
+}
+
+func testKnownHosts(t *testing.T) string {
+	t.Helper()
+	publicKey, _, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	sshPublicKey, err := ssh.NewPublicKey(publicKey)
+	require.NoError(t, err)
+	path := filepath.Join(t.TempDir(), "known_hosts")
+	require.NoError(t, os.WriteFile(path, append([]byte("github.com "), ssh.MarshalAuthorizedKey(sshPublicKey)...), 0600))
+	return path
+}
+
+type socketFileInfo struct{}
+
+func (socketFileInfo) Name() string       { return "agent.sock" }
+func (socketFileInfo) Size() int64        { return 0 }
+func (socketFileInfo) Mode() os.FileMode  { return os.ModeSocket }
+func (socketFileInfo) ModTime() time.Time { return time.Time{} }
+func (socketFileInfo) IsDir() bool        { return false }
+func (socketFileInfo) Sys() any           { return nil }
+
+func socketStat(string) (os.FileInfo, error) {
+	return socketFileInfo{}, nil
+}
+
+func TestResolveGitAuthNone(t *testing.T) {
+	auth, err := ResolveGitAuth(HeighlinerDockerBuildConfig{}, ChainNodeConfig{})
+	require.NoError(t, err)
+	require.Equal(t, GitAuthModeNone, auth.Mode)
+}
+
+func TestResolveGitAuthRejectsConflictingSources(t *testing.T) {
+	t.Setenv("GH_TOKEN", "secret")
+	_, err := ResolveGitAuth(HeighlinerDockerBuildConfig{
+		UseBuildKit:   true,
+		UseSSH:        true,
+		UseGitHubAuth: true,
+	}, ChainNodeConfig{Dockerfile: DockerfileTypeCosmos})
+	require.ErrorContains(t, err, "mutually exclusive")
+}
+
+func TestResolveStandardGitHubToken(t *testing.T) {
+	t.Setenv("GH_TOKEN", "primary-token")
+	t.Setenv("GITHUB_TOKEN", "fallback-token")
+
+	auth, err := ResolveGitAuth(HeighlinerDockerBuildConfig{
+		UseBuildKit:   true,
+		UseGitHubAuth: true,
+	}, ChainNodeConfig{Dockerfile: DockerfileTypeCosmos})
+	require.NoError(t, err)
+	require.Equal(t, GitAuthModeGitHubToken, auth.Mode)
+	require.Equal(t, "primary-token", auth.GitHubToken)
+	require.Contains(t, string(auth.Netrc()), "password primary-token")
+	cloneOptions, err := gitCloneOptions("github.com", "example", "private", auth)
+	require.NoError(t, err)
+	require.NotContains(t, cloneOptions.URL, "primary-token")
+	require.Equal(t, "https://github.com/example/private", cloneOptions.URL)
+	require.Equal(t, "primary-token", cloneOptions.Auth.(*githttp.BasicAuth).Password)
+
+	t.Setenv("GH_TOKEN", "")
+	auth, err = ResolveGitAuth(HeighlinerDockerBuildConfig{
+		UseBuildKit:   true,
+		UseGitHubAuth: true,
+	}, ChainNodeConfig{Dockerfile: DockerfileTypeCosmos})
+	require.NoError(t, err)
+	require.Equal(t, "fallback-token", auth.GitHubToken)
+
+	t.Setenv("GITHUB_TOKEN", "")
+	_, err = ResolveGitAuth(HeighlinerDockerBuildConfig{
+		UseBuildKit:   true,
+		UseGitHubAuth: true,
+	}, ChainNodeConfig{Dockerfile: DockerfileTypeCosmos})
+	require.ErrorContains(t, err, "requires GH_TOKEN or GITHUB_TOKEN")
+
+	_, err = ResolveGitAuth(HeighlinerDockerBuildConfig{
+		UseBuildKit:   true,
+		UseGitHubAuth: true,
+	}, ChainNodeConfig{RepoHost: "git.example.com", Dockerfile: DockerfileTypeCosmos})
+	require.ErrorContains(t, err, "only supports github.com")
+
+	_, err = ResolveGitAuth(HeighlinerDockerBuildConfig{
+		UseBuildKit:       true,
+		UseGitHubAuth:     true,
+		SSHKnownHostsPath: testKnownHosts(t),
+	}, ChainNodeConfig{Dockerfile: DockerfileTypeCosmos})
+	require.ErrorContains(t, err, "requires SSH authentication")
+}
+
+func TestNewAuthOptionsRequireBuildKit(t *testing.T) {
+	t.Setenv("GH_TOKEN", "github-token-value")
+	_, err := ResolveGitAuth(HeighlinerDockerBuildConfig{
+		UseGitHubAuth: true,
+	}, ChainNodeConfig{Dockerfile: DockerfileTypeCosmos})
+	require.ErrorContains(t, err, "require --use-buildkit")
+
+	_, err = ResolveGitAuth(HeighlinerDockerBuildConfig{
+		SSHKnownHostsPath: testKnownHosts(t),
+	}, ChainNodeConfig{Dockerfile: DockerfileTypeCosmos, CloneKey: testCloneKey(t)})
+	require.ErrorContains(t, err, "require --use-buildkit")
+}
+
+func TestNewAuthOptionsAreLimitedToCosmosDockerfiles(t *testing.T) {
+	t.Setenv("GH_TOKEN", "github-token-value")
+	_, err := ResolveGitAuth(HeighlinerDockerBuildConfig{
+		UseBuildKit:   true,
+		UseGitHubAuth: true,
+	}, ChainNodeConfig{Dockerfile: DockerfileTypeCargo})
+	require.ErrorContains(t, err, "only Cosmos Dockerfiles")
+}
+
+func TestResolveSSHAgentAndKnownHosts(t *testing.T) {
+	socketPath := "/tmp/test-agent.sock"
+	t.Setenv("SSH_AUTH_SOCK", socketPath)
+	t.Setenv("SSH_KNOWN_HOSTS", testKnownHosts(t))
+
+	auth, err := resolveGitAuth(HeighlinerDockerBuildConfig{
+		UseBuildKit: true,
+		UseSSH:      true,
+	}, ChainNodeConfig{Dockerfile: DockerfileTypeCosmos}, socketStat)
+	require.NoError(t, err)
+	require.Equal(t, GitAuthModeSSH, auth.Mode)
+	require.Equal(t, socketPath, auth.SSHAgentSocket)
+	require.NotEmpty(t, auth.SSHKnownHosts)
+}
+
+func TestResolveSSHRequiresAgentAndKnownHosts(t *testing.T) {
+	t.Setenv("SSH_AUTH_SOCK", "")
+	_, err := ResolveGitAuth(HeighlinerDockerBuildConfig{UseBuildKit: true, UseSSH: true}, ChainNodeConfig{Dockerfile: DockerfileTypeCosmos})
+	require.ErrorContains(t, err, "SSH_AUTH_SOCK")
+
+	socketPath := "/tmp/test-agent.sock"
+	t.Setenv("SSH_AUTH_SOCK", socketPath)
+	t.Setenv("SSH_KNOWN_HOSTS", "")
+	t.Setenv("HOME", t.TempDir())
+	_, err = resolveGitAuth(HeighlinerDockerBuildConfig{UseBuildKit: true, UseSSH: true}, ChainNodeConfig{Dockerfile: DockerfileTypeCosmos}, socketStat)
+	require.ErrorContains(t, err, "known_hosts")
+}
+
+func TestResolveCloneKeyEnvAndLegacyCloneKey(t *testing.T) {
+	encodedKey := testCloneKey(t)
+	knownHosts := testKnownHosts(t)
+	t.Setenv("PRIVATE_CLONE_KEY", encodedKey)
+
+	auth, err := ResolveGitAuth(HeighlinerDockerBuildConfig{
+		UseBuildKit:       true,
+		CloneKeyEnv:       "PRIVATE_CLONE_KEY",
+		SSHKnownHostsPath: knownHosts,
+	}, ChainNodeConfig{Dockerfile: DockerfileTypeCosmos})
+	require.NoError(t, err)
+	require.NotEmpty(t, auth.SSHPrivateKey)
+	require.False(t, auth.InsecureLegacyClone)
+
+	legacyAuth, err := ResolveGitAuth(HeighlinerDockerBuildConfig{}, ChainNodeConfig{CloneKey: encodedKey})
+	require.NoError(t, err)
+	require.True(t, legacyAuth.InsecureLegacyClone)
+	cloneOptions, err := gitCloneOptions("github.com", "example", "private", legacyAuth)
+	require.NoError(t, err)
+	require.Equal(t, "git@github.com:example/private.git", cloneOptions.URL)
+	require.IsType(t, &gitssh.PublicKeys{}, cloneOptions.Auth)
+}
+
+func TestGitAuthBuildConfigDoesNotPutBuildKitSecretsInArgs(t *testing.T) {
+	token := "token-must-not-be-an-arg"
+	args, sessionOptions := gitAuthBuildConfig(true, "legacy-key-must-not-be-an-arg", GitAuthConfig{
+		Mode:        GitAuthModeGitHubToken,
+		GitHubToken: token,
+	})
+	require.Equal(t, map[string]string{"GIT_AUTH_MODE": "github-token"}, args)
+	for key, value := range args {
+		require.NotContains(t, key, token)
+		require.NotContains(t, value, token)
+	}
+	require.Contains(t, string(sessionOptions.Secrets["git_netrc"]), token)
+
+	key := []byte("private-key-must-not-be-an-arg")
+	args, sessionOptions = gitAuthBuildConfig(true, string(key), GitAuthConfig{Mode: GitAuthModeSSH, SSHPrivateKey: key})
+	require.NotContains(t, strings.Join([]string{args["GIT_AUTH_MODE"], args["CLONE_KEY"]}, ""), string(key))
+	require.Equal(t, key, sessionOptions.SSHPrivateKey)
+
+	legacyArgs, _ := gitAuthBuildConfig(false, "legacy-key", GitAuthConfig{Mode: GitAuthModeSSH})
+	require.Equal(t, "legacy-key", legacyArgs["CLONE_KEY"])
+}
+
+func TestCloneKeyDeprecationWarnings(t *testing.T) {
+	warnings := CloneKeyDeprecationWarnings(HeighlinerDockerBuildConfig{}, ChainNodeConfig{CloneKey: "configured"})
+	require.Len(t, warnings, 2)
+	require.Contains(t, warnings[0], "deprecated")
+	require.Contains(t, warnings[1], "insecure legacy")
+
+	warnings = CloneKeyDeprecationWarnings(HeighlinerDockerBuildConfig{UseBuildKit: true}, ChainNodeConfig{CloneKey: "configured"})
+	require.Len(t, warnings, 1)
+}

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -521,7 +521,7 @@ func (h *HeighlinerBuilder) buildNextImage(wg *sync.WaitGroup) {
 	go func() {
 		if err := h.buildChainNodeDockerImage(chainConfig); err != nil {
 			h.errorsLock.Lock()
-			h.errors = append(h.errors, fmt.Errorf("error building docker image for %s from ref: %s - %v\n", chainConfig.Build.Name, chainConfig.Ref, err))
+			h.errors = append(h.errors, fmt.Errorf("error building docker image for %s from ref: %s - %v", chainConfig.Build.Name, chainConfig.Ref, err))
 			h.errorsLock.Unlock()
 		}
 		h.buildNextImage(wg)

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -2,8 +2,6 @@ package builder
 
 import (
 	"context"
-	"encoding/base64"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -18,6 +16,7 @@ import (
 	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
+	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	"github.com/go-git/go-git/v5/storage/memory"
 	internalssh "golang.org/x/crypto/ssh"
@@ -155,7 +154,7 @@ func getModFile(
 	repoHost string,
 	organization string,
 	repoName string,
-	cloneKey string,
+	auth GitAuthConfig,
 	ref string,
 	buildDir string,
 	local bool,
@@ -174,30 +173,12 @@ func getModFile(
 			return nil, fmt.Errorf("failed to read %s for local build: %w", goModPath, err)
 		}
 	} else {
-		// single branch depth 1 clone to only fetch most recent state of files
-		cloneOpts := &git.CloneOptions{
-			URL:          fmt.Sprintf("https://%s/%s/%s", repoHost, organization, repoName),
-			SingleBranch: true,
-			Depth:        1,
+		cloneOpts, err := gitCloneOptions(repoHost, organization, repoName, auth)
+		if err != nil {
+			return nil, err
 		}
 		// Try as tag ref first
 		cloneOpts.ReferenceName = plumbing.NewTagReferenceName(ref)
-		// if there is a clone key, decode and use it to authenticate
-		if cloneKey != "" {
-			cloneKeyBz, err := base64.StdEncoding.DecodeString(cloneKey)
-			if err != nil {
-				return nil, errors.New("failed to decode clone key")
-			}
-
-			key, err := ssh.NewPublicKeys("git", cloneKeyBz, "")
-			if err != nil {
-				return nil, errors.New("failed to generate public key")
-			}
-			key.HostKeyCallback = internalssh.InsecureIgnoreHostKey()
-
-			cloneOpts.URL = fmt.Sprintf("git@%s:%s/%s.git", repoHost, organization, repoName)
-			cloneOpts.Auth = key
-		}
 
 		// Clone into memory
 		fs := memfs.New()
@@ -230,6 +211,50 @@ func getModFile(
 	}
 
 	return goMod, nil
+}
+
+func gitCloneOptions(repoHost, organization, repoName string, auth GitAuthConfig) (*git.CloneOptions, error) {
+	cloneOpts := &git.CloneOptions{
+		URL:          fmt.Sprintf("https://%s/%s/%s", repoHost, organization, repoName),
+		SingleBranch: true,
+		Depth:        1,
+	}
+
+	switch auth.Mode {
+	case GitAuthModeNone:
+		return cloneOpts, nil
+	case GitAuthModeGitHubToken:
+		cloneOpts.Auth = &githttp.BasicAuth{Username: "x-access-token", Password: auth.GitHubToken}
+		return cloneOpts, nil
+	case GitAuthModeSSH:
+		callback := internalssh.InsecureIgnoreHostKey()
+		if !auth.InsecureLegacyClone {
+			var err error
+			callback, err = ssh.NewKnownHostsCallback(auth.SSHKnownHostsPaths...)
+			if err != nil {
+				return nil, fmt.Errorf("configure SSH known_hosts verification: %w", err)
+			}
+		}
+		if auth.SSHAgentSocket != "" {
+			key, err := ssh.NewSSHAgentAuth("git")
+			if err != nil {
+				return nil, fmt.Errorf("configure SSH authentication: %w", err)
+			}
+			key.HostKeyCallback = callback
+			cloneOpts.Auth = key
+		} else {
+			key, err := ssh.NewPublicKeys("git", auth.SSHPrivateKey, "")
+			if err != nil {
+				return nil, fmt.Errorf("configure SSH authentication: %w", err)
+			}
+			key.HostKeyCallback = callback
+			cloneOpts.Auth = key
+		}
+		cloneOpts.URL = fmt.Sprintf("git@%s:%s/%s.git", repoHost, organization, repoName)
+		return cloneOpts, nil
+	default:
+		return nil, fmt.Errorf("unsupported Git authentication mode %q", auth.Mode)
+	}
 }
 
 func trimWasmvmVersionSuffix(repo string) string {
@@ -369,6 +394,11 @@ func (h *HeighlinerBuilder) buildChainNodeDockerImage(
 		repoHost = "github.com"
 	}
 
+	auth, err := ResolveGitAuth(buildCfg, chainConfig.Build)
+	if err != nil {
+		return fmt.Errorf("invalid private Git authentication: %w", err)
+	}
+
 	buildTimestamp := ""
 	if buildCfg.NoBuildCache {
 		buildTimestamp = strconv.FormatInt(time.Now().Unix(), 10)
@@ -380,7 +410,7 @@ func (h *HeighlinerBuilder) buildChainNodeDockerImage(
 
 	modFile, err := getModFile(
 		repoHost, chainConfig.Build.GithubOrganization, chainConfig.Build.GithubRepo,
-		chainConfig.Build.CloneKey, chainConfig.Ref, chainConfig.Build.BuildDir, h.local,
+		auth, chainConfig.Ref, chainConfig.Build.BuildDir, h.local,
 	)
 
 	goVersion := buildCfg.GoVersion
@@ -429,7 +459,6 @@ func (h *HeighlinerBuilder) buildChainNodeDockerImage(
 		"REPO_HOST":           repoHost,
 		"GITHUB_ORGANIZATION": chainConfig.Build.GithubOrganization,
 		"GITHUB_REPO":         chainConfig.Build.GithubRepo,
-		"CLONE_KEY":           chainConfig.Build.CloneKey,
 		"BUILD_TARGET":        chainConfig.Build.BuildTarget,
 		"BINARIES":            binaries,
 		"LIBRARIES":           libraries,
@@ -445,6 +474,10 @@ func (h *HeighlinerBuilder) buildChainNodeDockerImage(
 		"GO_VERSION":          gv.Version,
 		"WASMVM_VERSION":      wasmvmVersion,
 		"RACE":                race,
+	}
+	authBuildArgs, buildKitSession := gitAuthBuildConfig(buildCfg.UseBuildKit, chainConfig.Build.CloneKey, auth)
+	for arg, value := range authBuildArgs {
+		buildArgs[arg] = value
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(time.Minute*180))
@@ -475,6 +508,7 @@ func (h *HeighlinerBuilder) buildChainNodeDockerImage(
 			buildKitOptions.Platform = buildCfg.Platform
 		}
 		buildKitOptions.NoCache = buildCfg.NoCache
+		buildKitOptions.Session = buildKitSession
 		if err := docker.BuildDockerImageWithBuildKit(ctx, reldir, imageTags, push, buildCfg.TarExportPath, buildArgs, buildKitOptions); err != nil {
 			return err
 		}

--- a/builder/types.go
+++ b/builder/types.go
@@ -53,6 +53,10 @@ type HeighlinerDockerBuildConfig struct {
 	TarExportPath     string
 	UseBuildKit       bool
 	BuildKitAddr      string
+	UseSSH            bool
+	UseGitHubAuth     bool
+	SSHKnownHostsPath string
+	CloneKeyEnv       string
 	Platform          string
 	NoCache           bool
 	NoBuildCache      bool

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/strangelove-ventures/heighliner/builder"
+)
+
+func validateAuthenticationBeforeQueue(
+	buildConfig builder.HeighlinerDockerBuildConfig,
+	flags chainConfigFlags,
+	warnings io.Writer,
+) error {
+	var selected []builder.ChainNodeConfig
+	for _, chain := range chains {
+		if flags.chain != "" && chain.Name != flags.chain {
+			continue
+		}
+		selected = append(selected, applyChainOverrides(chain, flags))
+		if flags.ref != "" || flags.local {
+			break
+		}
+	}
+
+	if len(selected) == 0 {
+		selected = append(selected, applyChainOverrides(builder.ChainNodeConfig{Name: flags.chain}, flags))
+	}
+
+	for _, chain := range selected {
+		if _, err := builder.ResolveGitAuth(buildConfig, chain); err != nil {
+			return fmt.Errorf("invalid private Git authentication for chain %q: %w", chain.Name, err)
+		}
+		for _, warning := range builder.CloneKeyDeprecationWarnings(buildConfig, chain) {
+			if _, err := fmt.Fprintln(warnings, warning); err != nil {
+				return fmt.Errorf("write clone-key deprecation warning: %w", err)
+			}
+		}
+	}
+	return nil
+}

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/strangelove-ventures/heighliner/builder"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildCommandRegistersPrivateGitAuthenticationFlags(t *testing.T) {
+	command := BuildCmd()
+	for _, flag := range []string{flagSSH, flagSSHKnownHosts, flagGitHubAuth, flagCloneKeyEnv, flagCloneKey} {
+		require.NotNilf(t, command.PersistentFlags().Lookup(flag), "missing --%s", flag)
+	}
+	require.Nil(t, command.PersistentFlags().Lookup("github-token-env"))
+}
+
+func TestAuthenticationValidationRunsBeforeQueueing(t *testing.T) {
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
+
+	originalChains := chains
+	chains = []builder.ChainNodeConfig{{
+		Name:       "private-chain",
+		Dockerfile: builder.DockerfileTypeCosmos,
+	}}
+	t.Cleanup(func() { chains = originalChains })
+
+	var warnings strings.Builder
+	err := validateAuthenticationBeforeQueue(builder.HeighlinerDockerBuildConfig{
+		UseBuildKit:   true,
+		UseGitHubAuth: true,
+	}, chainConfigFlags{chain: "private-chain", ref: "private-ref"}, &warnings)
+	require.ErrorContains(t, err, "requires GH_TOKEN or GITHUB_TOKEN")
+	require.Empty(t, warnings.String())
+}

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -45,6 +45,10 @@ const (
 	flagRepo          = "repo"
 	flagRepoHost      = "repo-host"
 	flagCloneKey      = "clone-key"
+	flagCloneKeyEnv   = "clone-key-env"
+	flagSSH           = "ssh"
+	flagSSHKnownHosts = "ssh-known-hosts"
+	flagGitHubAuth    = "github-auth"
 	flagGitRef        = "git-ref"
 	flagDockerfile    = "dockerfile"
 	flagBuildDir      = "build-dir"
@@ -127,7 +131,7 @@ func BuildCmd() *cobra.Command {
 		Long: `By default, fetch the last 5 releases in the repositories specified in chains.yaml.
 For each tag that doesn't exist in the specified container repository,
 it will be built and pushed`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cmdFlags := cmd.Flags()
 
 			configFile, _ := cmdFlags.GetString(flagFile)
@@ -163,7 +167,11 @@ An optional flag --tag/-t is now available to override the resulting docker imag
 			}
 			// END DEPRECATION HANDLING
 
+			if err := validateAuthenticationBeforeQueue(buildConfig, chainConfig, cmd.ErrOrStderr()); err != nil {
+				return err
+			}
 			queueAndBuild(buildConfig, chainConfig)
+			return nil
 		},
 	}
 
@@ -183,7 +191,11 @@ An optional flag --tag/-t is now available to override the resulting docker imag
 	buildCmd.PersistentFlags().StringVarP(&chainConfig.orgOverride, flagOrg, "o", "", "github-organization override for building from a fork")
 	buildCmd.PersistentFlags().StringVar(&chainConfig.repoOverride, flagRepo, "", "github-repo override for building from a fork")
 	buildCmd.PersistentFlags().StringVar(&chainConfig.repoHostOverride, flagRepoHost, "", "repo-host Git repository host override for building from a fork")
-	buildCmd.PersistentFlags().StringVar(&chainConfig.cloneKeyOverride, flagCloneKey, "", "base64 encoded ssh key to authenticate")
+	buildCmd.PersistentFlags().StringVar(&chainConfig.cloneKeyOverride, flagCloneKey, "", "DEPRECATED: base64 encoded SSH key to authenticate")
+	buildCmd.PersistentFlags().StringVar(&buildConfig.CloneKeyEnv, flagCloneKeyEnv, "", "Environment variable containing a base64 encoded SSH clone key (BuildKit only)")
+	buildCmd.PersistentFlags().BoolVar(&buildConfig.UseSSH, flagSSH, false, "Forward SSH_AUTH_SOCK for private Git authentication (BuildKit only)")
+	buildCmd.PersistentFlags().StringVar(&buildConfig.SSHKnownHostsPath, flagSSHKnownHosts, "", "SSH known_hosts path (defaults to SSH_KNOWN_HOSTS, then ~/.ssh/known_hosts)")
+	buildCmd.PersistentFlags().BoolVar(&buildConfig.UseGitHubAuth, flagGitHubAuth, false, "Use a GitHub token from GH_TOKEN, then GITHUB_TOKEN (BuildKit only)")
 	buildCmd.PersistentFlags().StringVar(&chainConfig.dockerfileOverride, flagDockerfile, "", "dockerfile override (cosmos, cargo, imported, none)")
 	buildCmd.PersistentFlags().StringVar(&chainConfig.buildDirOverride, flagBuildDir, "", "build-dir override - repo relative directory to run build target")
 	buildCmd.PersistentFlags().StringVar(&chainConfig.preBuildOverride, flagPreBuild, "", "pre-build override - command(s) to run prior to build-target")

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -90,7 +90,7 @@ func list() {
 			printError(fmt.Errorf("GET %s: %s", url, resp.Status))
 			continue
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			printError(err)

--- a/cmd/queue.go
+++ b/cmd/queue.go
@@ -51,7 +51,7 @@ func mostRecentReleasesForChain(
 		return builder.HeighlinerQueuedChainBuilds{}, fmt.Errorf("status code: %v", res.StatusCode)
 	}
 
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 
 	body, err := io.ReadAll(res.Body)
 	if err != nil {

--- a/cmd/queue.go
+++ b/cmd/queue.go
@@ -88,30 +88,7 @@ func queueAndBuild(
 		if chainConfig.chain != "" && chainNodeConfig.Name != chainConfig.chain {
 			continue
 		}
-		if chainConfig.orgOverride != "" {
-			chainNodeConfig.GithubOrganization = chainConfig.orgOverride
-		}
-		if chainConfig.repoOverride != "" {
-			chainNodeConfig.GithubRepo = chainConfig.repoOverride
-		}
-		if chainConfig.repoHostOverride != "" {
-			chainNodeConfig.RepoHost = chainConfig.repoHostOverride
-		}
-		if chainConfig.cloneKeyOverride != "" {
-			chainNodeConfig.CloneKey = chainConfig.cloneKeyOverride
-		}
-		if chainConfig.buildTargetOverride != "" {
-			chainNodeConfig.BuildTarget = chainConfig.buildTargetOverride
-		}
-		if chainConfig.buildEnvOverride != "" {
-			chainNodeConfig.BuildEnv = strings.Split(chainConfig.buildEnvOverride, " ")
-		}
-		if chainConfig.binariesOverride != "" {
-			chainNodeConfig.Binaries = strings.Split(chainConfig.binariesOverride, " ")
-		}
-		if chainConfig.librariesOverride != "" {
-			chainNodeConfig.Libraries = strings.Split(chainConfig.librariesOverride, " ")
-		}
+		chainNodeConfig = applyChainOverrides(chainNodeConfig, chainConfig)
 		chainQueuedBuilds := builder.HeighlinerQueuedChainBuilds{ChainConfigs: []builder.ChainNodeDockerBuildConfig{}}
 		if chainConfig.ref != "" || chainConfig.local {
 			chainConfig := builder.ChainNodeDockerBuildConfig{
@@ -137,20 +114,11 @@ func queueAndBuild(
 	if heighlinerBuilder.QueueLen() == 0 {
 		chainQueuedBuilds := builder.HeighlinerQueuedChainBuilds{ChainConfigs: []builder.ChainNodeDockerBuildConfig{}}
 		chainConfig := builder.ChainNodeDockerBuildConfig{
-			Build: builder.ChainNodeConfig{
-				Name:               chainConfig.chain,
-				RepoHost:           chainConfig.repoHostOverride,
-				GithubOrganization: chainConfig.orgOverride,
-				GithubRepo:         chainConfig.repoOverride,
-				CloneKey:           chainConfig.cloneKeyOverride,
-				Dockerfile:         builder.DockerfileType(chainConfig.dockerfileOverride),
-				PreBuild:           chainConfig.preBuildOverride,
-				BuildTarget:        chainConfig.buildTargetOverride,
-				BuildEnv:           strings.Split(chainConfig.buildEnvOverride, " "),
-				BuildDir:           chainConfig.buildDirOverride,
-				Binaries:           strings.Split(chainConfig.binariesOverride, " "),
-				Libraries:          strings.Split(chainConfig.librariesOverride, " "),
-			},
+			Build: applyChainOverrides(builder.ChainNodeConfig{
+				Name:     chainConfig.chain,
+				PreBuild: chainConfig.preBuildOverride,
+				BuildDir: chainConfig.buildDirOverride,
+			}, chainConfig),
 			Ref:    chainConfig.ref,
 			Tag:    chainConfig.tag,
 			Latest: chainConfig.latest,
@@ -160,4 +128,35 @@ func queueAndBuild(
 	}
 
 	heighlinerBuilder.BuildImages()
+}
+
+func applyChainOverrides(chain builder.ChainNodeConfig, flags chainConfigFlags) builder.ChainNodeConfig {
+	if flags.orgOverride != "" {
+		chain.GithubOrganization = flags.orgOverride
+	}
+	if flags.repoOverride != "" {
+		chain.GithubRepo = flags.repoOverride
+	}
+	if flags.repoHostOverride != "" {
+		chain.RepoHost = flags.repoHostOverride
+	}
+	if flags.cloneKeyOverride != "" {
+		chain.CloneKey = flags.cloneKeyOverride
+	}
+	if flags.dockerfileOverride != "" {
+		chain.Dockerfile = builder.DockerfileType(flags.dockerfileOverride)
+	}
+	if flags.buildTargetOverride != "" {
+		chain.BuildTarget = flags.buildTargetOverride
+	}
+	if flags.buildEnvOverride != "" {
+		chain.BuildEnv = strings.Split(flags.buildEnvOverride, " ")
+	}
+	if flags.binariesOverride != "" {
+		chain.Binaries = strings.Split(flags.binariesOverride, " ")
+	}
+	if flags.librariesOverride != "" {
+		chain.Libraries = strings.Split(flags.librariesOverride, " ")
+	}
+	return chain
 }

--- a/docker/buildkit.go
+++ b/docker/buildkit.go
@@ -13,6 +13,8 @@ import (
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/auth/authprovider"
+	"github.com/moby/buildkit/session/secrets/secretsprovider"
+	"github.com/moby/buildkit/session/sshforward/sshprovider"
 	"github.com/moby/buildkit/util/entitlements"
 	"github.com/moby/buildkit/util/progress/progresswriter"
 	"github.com/sirupsen/logrus"
@@ -22,13 +24,75 @@ import (
 const BuildKitSock = "unix:///run/buildkit/buildkitd.sock"
 const DefaultPlatforms = "linux/arm64,linux/amd64"
 
+const (
+	GitKnownHostsSecretID = "git_known_hosts"
+	GitNetrcSecretID      = "git_netrc"
+)
+
+type BuildKitSessionOptions struct {
+	SSHAgentSocket string
+	SSHPrivateKey  []byte
+	Secrets        map[string][]byte
+}
+
 type BuildKitOptions struct {
 	Address  string
 	Platform string
 	NoCache  bool
+	Session  BuildKitSessionOptions
 
 	// Set type of progress (auto, plain, tty). Use plain to show container output
 	LogBuildProgress string
+}
+
+func buildKitSessionAttachables(options BuildKitSessionOptions) ([]session.Attachable, error) {
+	attachable := make([]session.Attachable, 0, 2)
+	if options.SSHAgentSocket != "" && len(options.SSHPrivateKey) != 0 {
+		return nil, fmt.Errorf("cannot forward both an SSH agent and a private key")
+	}
+
+	sshPath := options.SSHAgentSocket
+	if len(options.SSHPrivateKey) != 0 {
+		keyFile, err := os.CreateTemp("", "heighliner-buildkit-ssh-key-")
+		if err != nil {
+			return nil, fmt.Errorf("create temporary SSH key: %w", err)
+		}
+		keyPath := keyFile.Name()
+		defer func() { _ = os.Remove(keyPath) }()
+		if _, err := keyFile.Write(options.SSHPrivateKey); err != nil {
+			_ = keyFile.Close()
+			return nil, fmt.Errorf("write temporary SSH key: %w", err)
+		}
+		if err := keyFile.Close(); err != nil {
+			return nil, fmt.Errorf("close temporary SSH key: %w", err)
+		}
+		sshPath = keyPath
+	}
+
+	if sshPath != "" {
+		provider, err := sshprovider.NewSSHAgentProvider([]sshprovider.AgentConfig{{Paths: []string{sshPath}}})
+		if err != nil {
+			return nil, fmt.Errorf("create BuildKit SSH provider: %w", err)
+		}
+		attachable = append(attachable, provider)
+	}
+	if len(options.Secrets) != 0 {
+		attachable = append(attachable, secretsprovider.FromMap(options.Secrets))
+	}
+	return attachable, nil
+}
+
+func buildKitFrontendAttrs(args map[string]string, buildKitOptions BuildKitOptions) map[string]string {
+	opts := map[string]string{
+		"platform": buildKitOptions.Platform,
+	}
+	for arg, value := range args {
+		opts[fmt.Sprintf("build-arg:%s", arg)] = value
+	}
+	if buildKitOptions.NoCache {
+		opts["no-cache"] = ""
+	}
+	return opts
 }
 
 func GetDefaultBuildKitOptions() BuildKitOptions {
@@ -68,6 +132,11 @@ func BuildDockerImageWithBuildKit(
 
 	dockerConfig := config.LoadDefaultConfigFile(os.Stderr)
 	attachable := []session.Attachable{authprovider.NewDockerAuthProvider(dockerConfig)}
+	authAttachables, err := buildKitSessionAttachables(buildKitOptions.Session)
+	if err != nil {
+		return err
+	}
+	attachable = append(attachable, authAttachables...)
 
 	eg, ctx := errgroup.WithContext(ctx)
 
@@ -105,12 +174,7 @@ func BuildDockerImageWithBuildKit(
 		exports[0] = export
 	}
 
-	opts := map[string]string{
-		"platform": buildKitOptions.Platform,
-	}
-	for arg, value := range args {
-		opts[fmt.Sprintf("build-arg:%s", arg)] = value
-	}
+	opts := buildKitFrontendAttrs(args, buildKitOptions)
 
 	locals := map[string]string{
 		"context":    ".",
@@ -131,10 +195,6 @@ func BuildDockerImageWithBuildKit(
 	}
 
 	var def *llb.Definition
-
-	if buildKitOptions.NoCache {
-		solveOpt.FrontendAttrs["no-cache"] = ""
-	}
 
 	// not using shared context to not disrupt display but let is finish reporting errors
 	pw, err := progresswriter.NewPrinter(ctx, os.Stderr, buildKitOptions.LogBuildProgress)

--- a/docker/buildkit_integration_test.go
+++ b/docker/buildkit_integration_test.go
@@ -1,0 +1,71 @@
+package docker
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildKitAuthenticationSessionMounts(t *testing.T) {
+	buildKitAddress := os.Getenv("BUILDKIT_ADDR")
+	if buildKitAddress == "" {
+		t.Skip("BUILDKIT_ADDR is not set")
+	}
+
+	placeholder, err := os.CreateTemp("/tmp", "hl-buildkit-agent-")
+	require.NoError(t, err)
+	sshSocket := placeholder.Name()
+	require.NoError(t, placeholder.Close())
+	require.NoError(t, os.Remove(sshSocket))
+	listener, err := net.Listen("unix", sshSocket)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = listener.Close()
+		_ = os.Remove(sshSocket)
+	})
+
+	dockerfileDir := t.TempDir()
+	dockerfile := `FROM busybox:1.36.1-musl
+RUN mkdir -p /root/.ssh
+RUN --mount=type=ssh,required=true \
+    --mount=type=secret,id=git_netrc,target=/root/.netrc,required=true \
+    --mount=type=secret,id=git_known_hosts,target=/root/.ssh/known_hosts,required=true \
+    test -S /run/buildkit/ssh_agent.0 && \
+    grep -q "dummy-netrc-value" /root/.netrc && \
+    grep -q "dummy-known-host-value" /root/.ssh/known_hosts
+RUN test ! -e /root/.netrc && \
+    test ! -e /root/.ssh/known_hosts && \
+    test ! -e /run/buildkit/ssh_agent.0
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dockerfileDir, "Dockerfile"), []byte(dockerfile), 0600))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	err = BuildDockerImageWithBuildKit(
+		ctx,
+		dockerfileDir,
+		[]string{"heighliner-buildkit-auth-integration:session-mounts"},
+		false,
+		"",
+		map[string]string{"GIT_AUTH_MODE": "ssh"},
+		BuildKitOptions{
+			Address:          buildKitAddress,
+			Platform:         "linux/amd64",
+			NoCache:          true,
+			LogBuildProgress: "plain",
+			Session: BuildKitSessionOptions{
+				SSHAgentSocket: sshSocket,
+				Secrets: map[string][]byte{
+					GitNetrcSecretID:      []byte("dummy-netrc-value"),
+					GitKnownHostsSecretID: []byte("dummy-known-host-value"),
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+}

--- a/docker/buildkit_test.go
+++ b/docker/buildkit_test.go
@@ -1,0 +1,60 @@
+package docker
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+func testSSHPrivateKey(t *testing.T) []byte {
+	t.Helper()
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	block, err := ssh.MarshalPrivateKey(privateKey, "heighliner-test")
+	require.NoError(t, err)
+	return pem.EncodeToMemory(block)
+}
+
+func TestBuildKitFrontendAttrsContainOnlyNonSecretAuthMode(t *testing.T) {
+	secret := "must-not-appear"
+	options := BuildKitOptions{
+		Platform: "linux/amd64",
+		NoCache:  true,
+		Session: BuildKitSessionOptions{Secrets: map[string][]byte{
+			GitNetrcSecretID: []byte(secret),
+		}},
+	}
+	attrs := buildKitFrontendAttrs(map[string]string{
+		"GIT_AUTH_MODE": "github-token",
+		"NAME":          "example",
+	}, options)
+
+	require.Equal(t, "github-token", attrs["build-arg:GIT_AUTH_MODE"])
+	require.Contains(t, attrs, "no-cache")
+	for key, value := range attrs {
+		require.NotContains(t, key, secret)
+		require.NotContains(t, value, secret)
+	}
+}
+
+func TestBuildKitSessionAttachables(t *testing.T) {
+	attachables, err := buildKitSessionAttachables(BuildKitSessionOptions{
+		SSHPrivateKey: testSSHPrivateKey(t),
+		Secrets: map[string][]byte{
+			GitKnownHostsSecretID: []byte("github.com ssh-ed25519 test"),
+			GitNetrcSecretID:      []byte("machine github.com"),
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, attachables, 2)
+
+	_, err = buildKitSessionAttachables(BuildKitSessionOptions{
+		SSHAgentSocket: "/tmp/agent.sock",
+		SSHPrivateKey:  testSSHPrivateKey(t),
+	})
+	require.ErrorContains(t, err, "both an SSH agent and a private key")
+}

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -100,7 +100,7 @@ func BuildDockerImage(ctx context.Context, dockerfile string, tags []string, pus
 			return err
 		}
 
-		defer rd.Close()
+		defer func() { _ = rd.Close() }()
 
 		buf := new(strings.Builder)
 		_, err = io.Copy(buf, rd)

--- a/dockerfile/auth_test.go
+++ b/dockerfile/auth_test.go
@@ -1,0 +1,33 @@
+package dockerfile
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCosmosBuildKitDockerfilesUseSessionMounts(t *testing.T) {
+	for name, dockerfile := range map[string][]byte{
+		"remote":      Cosmos,
+		"local-cross": CosmosLocalCross,
+	} {
+		t.Run(name, func(t *testing.T) {
+			contents := string(dockerfile)
+			_, err := parser.Parse(bytes.NewReader(dockerfile))
+			require.NoError(t, err)
+			require.Contains(t, contents, "ARG GIT_AUTH_MODE=none")
+			require.Contains(t, contents, "--mount=type=ssh")
+			require.Contains(t, contents, "id=git_known_hosts")
+			require.Contains(t, contents, "id=git_netrc")
+			require.Contains(t, contents, "StrictHostKeyChecking=yes")
+			require.NotContains(t, contents, "ARG CLONE_KEY")
+			require.NotContains(t, contents, "base64 -d")
+			require.NotContains(t, contents, "id_ed25519")
+		})
+	}
+
+	require.GreaterOrEqual(t, strings.Count(string(Cosmos), "--mount=type=ssh"), 2, "remote clone and build must both mount SSH")
+}

--- a/dockerfile/cosmos/Dockerfile
+++ b/dockerfile/cosmos/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_VERSION
 FROM --platform=$BUILDPLATFORM golang:${BASE_VERSION} AS build-env
 
-RUN apk add --update --no-cache curl make git libc-dev bash gcc linux-headers eudev-dev
+RUN apk add --update --no-cache curl make git openssh-client libc-dev bash gcc linux-headers eudev-dev
 
 ARG TARGETARCH
 ARG BUILDARCH
@@ -12,27 +12,32 @@ RUN if [ "${TARGETARCH}" = "arm64" ] && [ "${BUILDARCH}" != "arm64" ]; then\
         wget -c https://storage.googleapis.com/strangelove-public/musl/x86_64-linux-musl-cross.tgz -O - | tar -xzvv --strip-components 1 -C /usr;\
     fi
 
-ARG CLONE_KEY
-
-RUN if [ ! -z "${CLONE_KEY}" ]; then\
-        mkdir -p ~/.ssh;\
-        echo "${CLONE_KEY}" | base64 -d > ~/.ssh/id_ed25519;\
-        chmod 600 ~/.ssh/id_ed25519;\
-        apk add openssh;\
-        git config --global --add url."ssh://git@github.com/".insteadOf "https://github.com/";\
-        ssh-keyscan github.com >> ~/.ssh/known_hosts;\
-    fi
-
 ARG GITHUB_ORGANIZATION
 ARG REPO_HOST
+ARG GIT_AUTH_MODE=none
 
 WORKDIR /go/src/${REPO_HOST}/${GITHUB_ORGANIZATION}
+RUN mkdir -p /root/.ssh
 
 ARG GITHUB_REPO
 ARG VERSION
 ARG BUILD_TIMESTAMP
 
-RUN git clone -b ${VERSION} --single-branch https://${REPO_HOST}/${GITHUB_ORGANIZATION}/${GITHUB_REPO}.git --recursive
+RUN --mount=type=ssh \
+    --mount=type=secret,id=git_known_hosts,target=/root/.ssh/known_hosts \
+    --mount=type=secret,id=git_netrc,target=/root/.netrc \
+    set -eu; \
+    case "${GIT_AUTH_MODE}" in \
+      ssh) \
+        git config --global "url.ssh://git@${REPO_HOST}/.insteadOf" "https://${REPO_HOST}/"; \
+        export GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=yes -o UserKnownHostsFile=/root/.ssh/known_hosts"; \
+        git clone -b "${VERSION}" --single-branch "git@${REPO_HOST}:${GITHUB_ORGANIZATION}/${GITHUB_REPO}.git" --recursive; \
+        ;; \
+      github-token|none) \
+        git clone -b "${VERSION}" --single-branch "https://${REPO_HOST}/${GITHUB_ORGANIZATION}/${GITHUB_REPO}.git" --recursive; \
+        ;; \
+      *) echo "invalid GIT_AUTH_MODE: ${GIT_AUTH_MODE}" >&2; exit 1 ;; \
+    esac
 
 WORKDIR /go/src/${REPO_HOST}/${GITHUB_ORGANIZATION}/${GITHUB_REPO}
 
@@ -43,7 +48,14 @@ ARG PRE_BUILD
 ARG BUILD_DIR
 ARG WASMVM_VERSION
 
-RUN set -eux;\
+RUN --mount=type=ssh \
+    --mount=type=secret,id=git_known_hosts,target=/root/.ssh/known_hosts \
+    --mount=type=secret,id=git_netrc,target=/root/.netrc \
+    set -eux;\
+    if [ "${GIT_AUTH_MODE}" = "ssh" ]; then\
+      git config --global "url.ssh://git@${REPO_HOST}/.insteadOf" "https://${REPO_HOST}/";\
+      export GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=yes -o UserKnownHostsFile=/root/.ssh/known_hosts";\
+    fi;\
     LIBDIR=/lib;\
     if [ "${TARGETARCH}" = "arm64" ]; then\
       export ARCH=aarch64;\

--- a/dockerfile/cosmos/localcross.Dockerfile
+++ b/dockerfile/cosmos/localcross.Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_VERSION
 FROM --platform=$BUILDPLATFORM golang:${BASE_VERSION} AS build-env
 
-RUN apk add --update --no-cache curl make git libc-dev bash gcc linux-headers eudev-dev
+RUN apk add --update --no-cache curl make git openssh-client libc-dev bash gcc linux-headers eudev-dev
 
 ARG TARGETARCH
 ARG BUILDARCH
@@ -20,8 +20,10 @@ WORKDIR /go/src/${REPO_HOST}/${GITHUB_ORGANIZATION}/${GITHUB_REPO}
 ARG GITHUB_REPO
 ARG VERSION
 ARG BUILD_TIMESTAMP
+ARG GIT_AUTH_MODE=none
 
 ADD . .
+RUN mkdir -p /root/.ssh
 
 ARG BUILD_TARGET
 ARG BUILD_ENV
@@ -30,18 +32,14 @@ ARG PRE_BUILD
 ARG BUILD_DIR
 ARG WASMVM_VERSION
 
-ARG CLONE_KEY
-
-RUN if [ ! -z "${CLONE_KEY}" ]; then\
-  mkdir -p ~/.ssh;\
-  echo "${CLONE_KEY}" | base64 -d > ~/.ssh/id_ed25519;\
-  chmod 600 ~/.ssh/id_ed25519;\
-  apk add openssh;\
-  git config --global --add url."ssh://git@github.com/".insteadOf "https://github.com/";\
-  ssh-keyscan github.com >> ~/.ssh/known_hosts;\
-  fi
-
-RUN set -eux;\
+RUN --mount=type=ssh \
+    --mount=type=secret,id=git_known_hosts,target=/root/.ssh/known_hosts \
+    --mount=type=secret,id=git_netrc,target=/root/.netrc \
+    set -eux;\
+    if [ "${GIT_AUTH_MODE}" = "ssh" ]; then\
+      git config --global "url.ssh://git@${REPO_HOST}/.insteadOf" "https://${REPO_HOST}/";\
+      export GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=yes -o UserKnownHostsFile=/root/.ssh/known_hosts";\
+    fi;\
     LIBDIR=/lib;\
     if [ "${TARGETARCH}" = "arm64" ]; then\
       export ARCH=aarch64;\


### PR DESCRIPTION
## Summary

  Add secure private Git authentication for BuildKit-based Cosmos builds.

  - `--github-auth`: use `GH_TOKEN`, falling back to `GITHUB_TOKEN`
  - `--ssh`: forward `SSH_AUTH_SOCK`
  - `--ssh-known-hosts`: configure strict host-key verification
  - `--clone-key-env`: retain environment-based legacy key compatibility

  GitHub tokens are provided as temporary `.netrc` secrets, while SSH agents and legacy keys use BuildKit SSH sessions. Credentials are not included in CLI arguments, build arguments, frontend attributes, image layers, or logs.

  ## Usage

  For a Cosmos chain whose `go.mod` references a private GitHub module:

  ```shell
  export GH_TOKEN=github_app_installation_token

  heighliner build \
    --use-buildkit \
    --github-auth \
    --local \
    --dockerfile cosmos \
    --build-env "GOPRIVATE=github.com/example-org/*" \
    --build-target "make install" \
    --binaries "/go/bin/exampled" \
    -c example
```
  ## Compatibility and scope

  The existing --clone-key flag and YAML property remain supported but deprecated. BuildKit converts legacy keys into SSH sessions; non-BuildKit builds retain the existing behavior with an insecure legacy-path warning.

  New authentication options require BuildKit and currently support Cosmos Dockerfiles only. No version, tag, release, Cargo, Avalanche, or build-action changes are included.

  ## Testing

  - go test ./...
  - go vet ./...
  - golangci-lint run
  - BuildKit v0.12.5 integration coverage for ephemeral .netrc, known_hosts, and SSH mounts
  - Manual Linux ARM64 Cosmos build fetching a private go.mod dependency with a GitHub App installation token

  ## Follow-up

  heighliner-build-action@v1.0.3 does not pass GH_TOKEN to the Heighliner child process or enable --github-auth.

  A separate action PR should add a private-module token input, forward it as GH_TOKEN, and enable --github-auth without placing the token in command arguments.